### PR TITLE
Add SetFailure to AuditClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add a package for building audit rules that can be added to the kernel.
 - Add GetRules, DeleteRules, DeleteRule, and AddRule methods to AuditClient.
 - auparse - Add conversion of POSIX exit code values to their name.
+- Add SetFailure to AuditClient. #8
 
 ### Changed
 

--- a/audit.go
+++ b/audit.go
@@ -54,6 +54,18 @@ const (
 	NoWait
 )
 
+// FailureMode defines the kernel's behavior on critical errors.
+type FailureMode uint32
+
+const (
+	// SilentOnFailure ignores errors.
+	SilentOnFailure FailureMode = 0
+	// LogOnFailure logs errors using printk.
+	LogOnFailure
+	// PanicOnFailure causes a kernel panic on error.
+	PanicOnFailure
+)
+
 // AuditClient is a client for communicating with the Linux kernels audit
 // interface over netlink.
 type AuditClient struct {
@@ -299,6 +311,16 @@ func (c *AuditClient) SetEnabled(enabled bool, wm WaitMode) error {
 	status := AuditStatus{
 		Mask:    AuditStatusEnabled,
 		Enabled: e,
+	}
+	return c.set(status, wm)
+}
+
+// SetFailure sets the action that the kernel will perform when the backlog
+// limit is reached or when it encounters an error and cannot proceed.
+func (c *AuditClient) SetFailure(fm FailureMode, wm WaitMode) error {
+	status := AuditStatus{
+		Mask:    AuditStatusFailure,
+		Failure: uint32(fm),
 	}
 	return c.set(status, wm)
 }

--- a/audit_test.go
+++ b/audit_test.go
@@ -283,6 +283,48 @@ func TestAuditClientSetEnabled(t *testing.T) {
 	assert.EqualValues(t, 1, status.Enabled)
 }
 
+func TestAuditClientSetFailure(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("must be root to enable audit")
+	}
+
+	var dumper io.WriteCloser
+	if *hexdump {
+		dumper = hex.Dumper(os.Stdout)
+		defer dumper.Close()
+	}
+
+	c, err := NewAuditClient(dumper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	err = c.SetFailure(LogOnFailure, WaitForReply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("SetFailure complete")
+
+	status, err := getStatus(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, LogOnFailure, status.Failure)
+
+	err = c.SetFailure(SilentOnFailure, WaitForReply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("SetFailure complete")
+
+	status, err = getStatus(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.EqualValues(t, SilentOnFailure, status.Failure)
+}
+
 func TestAuditClientSetRateLimit(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("must be root to set rate limit")


### PR DESCRIPTION
SetFailure sets the action that the kernel will perform when the backlog
limit is reached or when it encounters an error and cannot proceed.