### PR TITLE
Add support for listening to audit multicast group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add support for listening for audit messages using a multicast group. #9
+
 ### Changed
 
 ### Deprecated

--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -90,11 +90,13 @@ func read() error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create receive-only audit client")
 		}
+		defer client.Close()
 	} else {
 		client, err = libaudit.NewAuditClient(diagWriter)
 		if err != nil {
 			return errors.Wrap(err, "failed to create audit client")
 		}
+		defer client.Close()
 
 		status, err := client.GetStatus()
 		if err != nil {
@@ -128,7 +130,6 @@ func read() error {
 			return errors.Wrap(err, "failed to set audit PID")
 		}
 	}
-	defer client.Close()
 
 	return receive(client)
 }

--- a/netlink.go
+++ b/netlink.go
@@ -73,16 +73,16 @@ type NetlinkClient struct {
 // (this is useful for debugging).
 //
 // The returned NetlinkClient must be closed with Close() when finished.
-func NewNetlinkClient(proto int, readBuf []byte, resp io.Writer) (*NetlinkClient, error) {
+func NewNetlinkClient(proto int, groups uint32, readBuf []byte, resp io.Writer) (*NetlinkClient, error) {
 	s, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, proto)
 	if err != nil {
 		return nil, err
 	}
 
-	src := &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK}
+	src := &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK, Groups: groups}
 	if err = syscall.Bind(s, src); err != nil {
 		syscall.Close(s)
-		return nil, err
+		return nil, errors.Wrap(err, "bind failed")
 	}
 
 	pid, err := getPortID(s)

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -28,7 +28,7 @@ import (
 var _ NetlinkSendReceiver = &NetlinkClient{}
 
 func TestNewNetlinkClient(t *testing.T) {
-	c, err := NewNetlinkClient(syscall.NETLINK_AUDIT, nil, nil)
+	c, err := NewNetlinkClient(syscall.NETLINK_AUDIT, 0, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestNewNetlinkClient(t *testing.T) {
 	// First PID assigned by the kernel will be our actual PID.
 	assert.EqualValues(t, os.Getpid(), c.pid)
 
-	c2, err := NewNetlinkClient(syscall.NETLINK_AUDIT, nil, nil)
+	c2, err := NewNetlinkClient(syscall.NETLINK_AUDIT, 0, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds `NewMulticastAuditClient` that creates a client that listens to the audit multicast group that was added in kernel 3.16.

Closes #9