### PR TITLE
Helper to wait for async message completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
  
 ### Added
+
+- Added WaitForPendingACKs to receive pending ACK messages from the kernel. #14
  
 ### Changed
 


### PR DESCRIPTION
Added WaitForPendingACKs method to AuditClient to be used after executing
one or more asynchronous calls.

When some control operations are performed asynchronously (NoWait) it is
necessary to wait for their completion (ACK message) before executing a
Blocking operation (WaitForReply). Otherwise the sequence number gets
out of sync, causing blocking operations to fail.
  