### PR TITLE
Unregister PID from kernel on client close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added WaitForPendingACKs to receive pending ACK messages from the kernel. #14
+- The AuditClient will unregister with the kernel if `SetPID` has been called. #19
  
 ### Changed
 


### PR DESCRIPTION
If `SetPID` was used then unregister our PID for a clean exit. The tests run reliably with #18 and this change. 

Testing with:

`docker run -it --rm --privileged -v $PWD:/go/src/github.com/elastic/go-libaudit --pid=host libaudit /bin/bash`

```
root@e19e3a14177c:/go/src/github.com/elastic/go-libaudit# go test -v
=== RUN   TestAuditClientGetStatus
--- PASS: TestAuditClientGetStatus (0.00s)
	audit_test.go:57: Status: &{Mask:0 Enabled:1 Failure:0 PID:0 RateLimit:1233 BacklogLimit:10002 Lost:171 Backlog:0 FeatureBitmap:15 BacklogWaitTime:6000}
=== RUN   TestAuditClientGetStatusPermissionError
--- SKIP: TestAuditClientGetStatusPermissionError (0.00s)
	audit_test.go:62: must be non-root to test permission failure
=== RUN   TestDeleteRules
--- PASS: TestDeleteRules (0.00s)
	audit_test.go:112: 0 rules deleted
=== RUN   TestListRules
--- SKIP: TestListRules (0.00s)
=== RUN   TestAddRule
--- PASS: TestAddRule (0.09s)
	audit_test.go:170: rule added
=== RUN   TestAddDuplicateRule
--- PASS: TestAddDuplicateRule (0.10s)
=== RUN   TestAuditClientGetRules
--- PASS: TestAuditClientGetRules (0.00s)
=== RUN   TestAuditClientSetPID
--- PASS: TestAuditClientSetPID (0.00s)
	audit_test.go:253: SetPID complete
=== RUN   TestAuditClientSetEnabled
--- PASS: TestAuditClientSetEnabled (0.00s)
	audit_test.go:277: SetEnabled complete
=== RUN   TestAuditClientSetFailure
--- PASS: TestAuditClientSetFailure (0.10s)
	audit_test.go:307: SetFailure complete
	audit_test.go:319: SetFailure complete
=== RUN   TestAuditClientSetRateLimit
--- PASS: TestAuditClientSetRateLimit (0.00s)
	audit_test.go:350: SetRateLimit complete
=== RUN   TestAuditClientSetBacklogLimit
--- PASS: TestAuditClientSetBacklogLimit (0.00s)
	audit_test.go:381: SetBacklogLimit complete
=== RUN   TestMulticastAuditClient
--- PASS: TestMulticastAuditClient (2.52s)
	audit_test.go:422: received 0 messages
=== RUN   TestAuditClientReceive
--- PASS: TestAuditClientReceive (4.57s)
	audit_test.go:466: status=&{Mask:0 Enabled:0 Failure:0 PID:0 RateLimit:1233 BacklogLimit:10002 Lost:189 Backlog:0 FeatureBitmap:15 BacklogWaitTime:6000}, process_id=4993
	audit_test.go:502: Received: type=CONFIG_CHANGE, msg=audit(1516212703.208:386): audit_pid=4993 old=4993 auid=4294967295 ses=4294967295 res=0
	audit_test.go:452: get status: status=&{Mask:0 Enabled:1 Failure:0 PID:0 RateLimit:1233 BacklogLimit:1024 Lost:191 Backlog:0 FeatureBitmap:15 BacklogWaitTime:6000}, err=<nil>
=== RUN   TestAuditStatusMask
--- PASS: TestAuditStatusMask (0.00s)
=== RUN   TestAuditWaitForPendingACKs
--- PASS: TestAuditWaitForPendingACKs (0.00s)
	audit_test.go:559: WaitForPendingACKs complete
=== RUN   TestNewNetlinkClient
--- PASS: TestNewNetlinkClient (0.00s)
=== RUN   TestReassembler
=== RUN   TestReassembler/normal
=== RUN   TestReassembler/lost_messages
=== RUN   TestReassembler/out_of_order
=== RUN   TestReassembler/rollover
--- PASS: TestReassembler (0.02s)
    --- PASS: TestReassembler/normal (0.01s)
    --- PASS: TestReassembler/lost_messages (0.00s)
    --- PASS: TestReassembler/out_of_order (0.00s)
    --- PASS: TestReassembler/rollover (0.00s)
=== RUN   TestSequenceNumSliceSort
--- PASS: TestSequenceNumSliceSort (0.00s)
PASS
ok  	github.com/elastic/go-libaudit	7.412s
```