### PR TITLE
Add s390 and s390x to runtime arch list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- rules - Detect s390 or s390x as the runtime architecture (GOOS) and
+  automatically use the appropriate syscall name to number table without
+  requiring the rule to explicitly specify an arch (`-F arch=s390x`). #23
+
 ### Changed
 
 ### Deprecated

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -560,7 +560,7 @@ func getArch(arch string) (string, uint32, error) {
 	return realArch, archValue, nil
 }
 
-// getRuntimeArch returns the programs arch (not the machines arch).
+// getRuntimeArch returns the program's arch (not the machine's arch).
 func getRuntimeArch() (string, error) {
 	var arch string
 	switch runtime.GOARCH {
@@ -574,6 +574,10 @@ func getRuntimeArch() (string, error) {
 		arch = "x86_64"
 	case "ppc64", "ppc64le":
 		arch = "ppc"
+	case "s390":
+		arch = "s390"
+	case "s390x":
+		arch = "s390x"
 	case "mips", "mipsle", "mips64", "mips64le":
 		fallthrough
 	default:


### PR DESCRIPTION
Detect s390 or s390x as the runtime architecture (GOOS) and
automatically use the appropriate syscall name to number table without
requiring the rule to explicitly specify an arch (`-F arch=s390x`).

Prior to this change, `-F arch=s390` or `-F arch=s390x` was required in a syscall audit
rule for these architectures.