### PR TITLE
Better errors when kernel does not support auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added better error messages for when `NewAuditClient` fails due to the
+  Linux kernel not supporting auditing (CONFIG_AUDIT=n). #32
+
 ### Changed
 
 ### Deprecated

--- a/audit.go
+++ b/audit.go
@@ -105,7 +105,12 @@ func newAuditClient(netlinkGroups uint32, resp io.Writer) (*AuditClient, error) 
 
 	netlink, err := NewNetlinkClient(syscall.NETLINK_AUDIT, netlinkGroups, buf, resp)
 	if err != nil {
-		return nil, err
+		switch err {
+		case syscall.EINVAL, syscall.EPROTONOSUPPORT, syscall.EAFNOSUPPORT:
+			return nil, errors.Wrap(err, "audit not supported by kernel")
+		default:
+			return nil, errors.Wrap(err, "failed to open audit netlink socket")
+		}
 	}
 
 	return &AuditClient{Netlink: netlink}, nil

--- a/audit_test.go
+++ b/audit_test.go
@@ -35,8 +35,7 @@ import (
 )
 
 // This can be run inside of Docker with:
-// docker run -it --rm -v `pwd`:/go/src/github.com/elastic/go-libaudit \
-//   --pid=host --privileged golang:1.8.3 /bin/bash
+// docker run -it --rm -v `pwd`:/go/src/github.com/elastic/go-libaudit --pid=host --privileged golang:1.10.1 /bin/bash
 
 var (
 	hexdump = flag.Bool("hexdump", false, "dump kernel responses to stdout in hexdump -C format")


### PR DESCRIPTION
libaudit.NewAuditClient() returns `EPROTONOSUPPORT` (protocol not supported) if the kernel does not have audit supported compiled in (CONFIG_AUDIT=y).

This change adds "audit not supported by kernel" to the error message when `EINVAL`, `EPROTONOSUPPORT`, or `EAFNOSUPPORT` are returned by the socket syscall.

Fixes #32