### PR TITLE
Make Close safe to call more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- AuditClient `Close()` is now safe to call more than once. #35
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
Any invocations beyond the first client `Close()` are now no-ops (implemented via `sync.Once`).

This also fixes another issue. The `clearPIDOnClose` was not being used. This client will now conditionally clear the PID value on `Close()`. This shouldn't have been causing any problems because only the controlling process would be allowed to clear the PID value, but it was incorrect.