### PR TITLE
Support backlog wait time feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added support for setting the kernel's backlog wait time via the new
+  SetBacklogWaitTime function. #34
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
This patch adds support for the backlog wait time feature by adding a new method: `AuditClient.SetBacklogWaitTime`.

This allows to specify the time (in jiffies) the kernel will wait for a buffer to become available in the backlog queue, if it becomes full. This delay can cause the thread invoking the syscall to block the audit client is not fast enough in consuming events. When the backlog wait time is set to zero, the kernel will discard the audit event (or whatever failure mode is set).

Closes #34