### PR TITLE
Add asynchronous status request via `GetStatusAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added support for setting the kernel's backlog wait time via the new
   SetBacklogWaitTime function. #34
+- New method `GetStatusAsync` to perform asynchronous status checks. #37
 
 ### Changed
 


### PR DESCRIPTION
Added method `GetStatusAsync` to perform asynchronous status checks.

These are necessary to query the status of the audit subsystem while the application is running an event read loop, so that the response can be received asynchronously.

Closes #37