### PR TITLE
Add method to convert kernel rules to display format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added method to convert kernel rules to text format in order to display them.
+
 ### Changed
 
 ### Deprecated

--- a/rule/binary.go
+++ b/rule/binary.go
@@ -104,9 +104,11 @@ func fromWireFormat(data WireFormat) (*auditRuleData, error) {
 		return nil, io.ErrUnexpectedEOF
 	}
 
-	rule.Buf = make([]byte, rule.BufLen)
-	if _, err := reader.Read(rule.Buf); err != nil {
-		return nil, err
+	if rule.BufLen > 0 {
+		rule.Buf = make([]byte, rule.BufLen)
+		if _, err := reader.Read(rule.Buf); err != nil {
+			return nil, errors.Wrap(err, "deserialization of buf failed")
+		}
 	}
 
 	return rule, nil

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -18,6 +18,8 @@
 package rule
 
 import (
+	"fmt"
+	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -45,10 +47,10 @@ func Build(rule Rule) (WireFormat, error) {
 
 	switch v := rule.(type) {
 	case *SyscallRule:
-		if err = addList(data, v.List); err != nil {
+		if err = data.setList(v.List); err != nil {
 			return nil, err
 		}
-		if err = addAction(data, v.Action); err != nil {
+		if err = data.setAction(v.Action); err != nil {
 			return nil, err
 		}
 
@@ -89,6 +91,227 @@ func Build(rule Rule) (WireFormat, error) {
 	}
 
 	return ard.toWireFormat(), nil
+}
+
+// ToCommandLine decodes a WireFormat into a command-line rule.
+// When resolveIds is set, it tries to resolve the argument to UIDs, GIDs,
+// file_type fields.
+// `auditctl -l` always prints the numeric (non-resolved) representation of
+// this fields, so when the flag is set to false, the output is the same as
+// auditctl.
+// There is an exception to this rule when parsing the `arch` field:
+// auditctl always prints "b64" or "b32" even for architectures other than
+// the current machine. This is misleading, so this code will print the actual
+// architecture.
+func ToCommandLine(wf WireFormat, resolveIds bool) (rule string, err error) {
+	ar, err := fromWireFormat(wf)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse wire format")
+	}
+
+	r := ruleData{}
+	if err = r.fromAuditRuleData(ar); err != nil {
+		return "", errors.Wrap(err, "failed to parse audit rule")
+	}
+
+	list, err := r.getList()
+	if err != nil {
+		return "", err
+	}
+
+	act, err := r.getAction()
+	if err != nil {
+		return "", err
+	}
+
+	existingFields := make(map[field]int)
+	for idx, fieldId := range r.fields {
+		existingFields[fieldId] = idx
+	}
+
+	// Detect if rule is a watch.
+	// Must have all syscalls and perm field. Only other valid fields are
+	// dir, path and key, according to auditctl source
+	if permIdx, ok := existingFields[permField]; r.allSyscalls && ok {
+		extraFields, pos := false, 0
+		var path, key string
+		for _, fieldId := range r.fields {
+			switch fieldId {
+			case keyField, pathField, dirField:
+				if pos >= len(r.strings) {
+					return "", fmt.Errorf("no buffer data for path field %d", fieldId)
+				}
+				if fieldId == keyField {
+					key = r.strings[pos]
+				} else {
+					path = r.strings[pos]
+				}
+				pos++
+			case permField:
+			default:
+				extraFields = true
+				break
+			}
+		}
+		if !extraFields {
+			arguments := []string{"-w", path, "-p", permission(r.values[permIdx]).String()}
+			if len(key) > 0 {
+				arguments = append(arguments, "-k", key)
+			}
+			return strings.Join(arguments, " "), nil
+		}
+	}
+
+	// Parse rule as syscall type
+
+	arguments := []string{
+		"-a",
+		fmt.Sprintf("%s,%s", act, list),
+	}
+
+	// Parse arch field first, if present
+	// Here there is a significant difference to what auditctl does.
+	// Auditctl will allow to install a rule for a different platform
+	// (i.e. "aarch64" when the actual platform is "x86_64"). A rule like this
+	// will never trigger any events in the kernel.
+	// When such a rule is printed with `auditctl -l`, it will show as
+	// "-F arch=b64", which is wrong.
+	// This code will print the real value, "aarch64".
+	if fieldIdx, found := existingFields[archField]; found {
+		r.arch, err = getDisplayArch(r.values[fieldIdx])
+		if err != nil {
+			return "", err
+		}
+		arguments = append(arguments, "-F", fmt.Sprintf("arch=%s", r.arch))
+	}
+
+	// Parse syscalls
+	if r.allSyscalls {
+		if r.flags == exitFilter || r.flags == entryFilter {
+			arguments = append(arguments, "-S", "all")
+		}
+	} else if len(r.syscalls) > 0 {
+		arch, err := getRuntimeArch()
+		if err != nil {
+			return "", err
+		}
+		if r.arch == "b32" {
+			switch arch {
+			case "aarch64":
+				arch = "arm"
+			case "x86_64":
+				arch = "i386"
+			case "ppc64", "ppc64le":
+				arch = "ppc"
+			default:
+				return "", errors.New("invalid arch for b32")
+			}
+		} else if r.arch != "b64" {
+			arch = r.arch
+		}
+		syscallTable, ok := auparse.AuditSyscalls[arch]
+		if !ok {
+			return "", fmt.Errorf("no syscall table for arch %s", arch)
+		}
+		list := make([]string, len(r.syscalls))
+		for idx, syscallId := range r.syscalls {
+			list[idx], ok = syscallTable[int(syscallId)]
+			if !ok {
+				return "", fmt.Errorf("syscall %d not found for arch %s", syscallId, arch)
+			}
+		}
+
+		arguments = append(arguments, "-S", strings.Join(list, ","))
+	}
+
+	// Parse fields
+	stringIndex := 0
+	for idx, fieldId := range r.fields {
+		op, found := reverseOperatorsTable[r.fieldFlags[idx]]
+		if !found {
+			return "", fmt.Errorf("field operator %x not found", r.fieldFlags[idx])
+		}
+		switch fieldId {
+		case archField:
+			// arch already handled
+		case fieldCompare:
+			fieldIds, found := reverseComparisonsTable[comparison(r.values[idx])]
+			if !found {
+				return "", errors.New("comparision code not valid")
+			}
+			if fieldIds[1] < fieldIds[0] {
+				fieldIds[0], fieldIds[1] = fieldIds[1], fieldIds[0]
+			}
+			var fields [2]string
+			for idx, id := range fieldIds {
+				if fields[idx], found = reverseFieldsTable[id]; !found {
+					return "", fmt.Errorf("unknown field %d", id)
+				}
+			}
+			arguments = append(arguments, fmt.Sprintf("-C %s%s%s",
+				fields[0], op, fields[1]))
+
+		default:
+			lhs, found := reverseFieldsTable[fieldId]
+			if !found {
+				return "", fmt.Errorf("field %x not found", fieldId)
+			}
+			value := r.values[idx]
+			var rhs string
+			switch fieldId {
+			// Fields that take a string
+			case objectUserField, objectRoleField, objectTypeField, objectLevelLowField,
+				objectLevelHighField, pathField, dirField, subjectUserField,
+				subjectRoleField, subjectTypeField, subjectSensitivityField,
+				subjectClearanceField, keyField, exeField:
+				if stringIndex >= len(r.strings) {
+					return "", errors.New("string buffer overflow")
+				}
+				rhs = r.strings[stringIndex]
+				stringIndex++
+			case exitField:
+				exitCode := int(int32(value))
+				if errnoValue, ok := auparse.AuditErrnoToName[-exitCode]; ok {
+					rhs = fmt.Sprintf("-%s", errnoValue)
+				} else {
+					rhs = strconv.Itoa(exitCode)
+				}
+			case uidField, euidField, suidField, fsuidField, auidField, objectUIDField:
+				rhs = strconv.Itoa(int(int32(value)))
+				if resolveIds {
+					if user, err := user.LookupId(rhs); err == nil {
+						rhs = user.Username
+					}
+				}
+			case gidField, egidField, sgidField, fsgidField, objectGIDField:
+				rhs = strconv.Itoa(int(int32(value)))
+				if resolveIds {
+					if group, err := user.LookupGroupId(rhs); err == nil {
+						rhs = group.Name
+					}
+				}
+			case msgTypeField:
+				if value <= math.MaxUint16 {
+					rhs = auparse.AuditMessageType(value).String()
+				} else {
+					rhs = fmt.Sprintf("UNKNOWN[%d]", value)
+				}
+			case permField:
+				rhs = permission(value).String()
+			case filetypeField:
+				if resolveIds {
+					rhs = filetype(value).String()
+				} else {
+					rhs = strconv.Itoa(int(value))
+				}
+			default:
+				rhs = strconv.Itoa(int(value))
+			}
+			arguments = append(arguments, fmt.Sprintf("-F %s%s%s", lhs, op, rhs))
+		}
+	}
+
+	return strings.Join(arguments, " "), nil
 }
 
 func addFileWatch(data *ruleData, rule *FileWatchRule) error {
@@ -203,7 +426,50 @@ func (d ruleData) toAuditRuleData() (*auditRuleData, error) {
 	return rule, nil
 }
 
-func addList(rule *ruleData, list string) error {
+func (rule *ruleData) fromAuditRuleData(in *auditRuleData) error {
+	rule.flags = in.Flags
+	rule.action = in.Action
+	rule.fields = make([]field, in.FieldCount)
+	rule.allSyscalls = true
+	for i := 0; rule.allSyscalls && i < len(in.Mask)-1; i++ {
+		rule.allSyscalls = in.Mask[i] == 0xFFFFFFFF
+	}
+	if rule.allSyscalls == false {
+		for word, bits := range in.Mask {
+			for bit := uint32(0); bit < 32; bit++ {
+				if bits&(1<<bit) != 0 {
+					rule.syscalls = append(rule.syscalls, uint32(word)*32+bit)
+				}
+			}
+		}
+	}
+	rule.fields = make([]field, in.FieldCount)
+	rule.fieldFlags = make([]operator, in.FieldCount)
+	rule.values = make([]uint32, in.FieldCount)
+
+	offset := uint32(0)
+	for i := uint32(0); i < in.FieldCount; i++ {
+		rule.fields[i] = in.Fields[i]
+		rule.fieldFlags[i] = in.FieldFlags[i]
+		rule.values[i] = in.Values[i]
+		switch rule.fields[i] {
+		case objectUserField, objectRoleField, objectTypeField, objectLevelLowField,
+			objectLevelHighField, pathField, dirField, subjectUserField,
+			subjectRoleField, subjectTypeField, subjectSensitivityField,
+			subjectClearanceField, keyField, exeField:
+			end := in.Values[i] + offset
+			if end > in.BufLen {
+				return fmt.Errorf("field %d overflows buffer", i)
+			}
+			rule.strings = append(rule.strings, string(in.Buf[offset:end]))
+			offset = end
+		}
+	}
+
+	return nil
+}
+
+func (rule *ruleData) setList(list string) error {
 	switch list {
 	case "exit":
 		rule.flags = exitFilter
@@ -220,7 +486,22 @@ func addList(rule *ruleData, list string) error {
 	return nil
 }
 
-func addAction(rule *ruleData, action string) error {
+func (rule *ruleData) getList() (string, error) {
+	switch rule.flags {
+	case exitFilter:
+		return "exit", nil
+	case taskFilter:
+		return "task", nil
+	case userFilter:
+		return "user", nil
+	case excludeFilter:
+		return "exclude", nil
+	default:
+		return "", errors.Errorf("invalid list flag '%v'", rule.flags)
+	}
+}
+
+func (rule *ruleData) setAction(action string) error {
 	switch action {
 	case "always":
 		rule.action = alwaysAction
@@ -231,6 +512,17 @@ func addAction(rule *ruleData, action string) error {
 	}
 
 	return nil
+}
+
+func (rule *ruleData) getAction() (string, error) {
+	switch rule.action {
+	case alwaysAction:
+		return "always", nil
+	case neverAction:
+		return "never", nil
+	default:
+		return "", errors.Errorf("invalid action '%v'", rule.action)
+	}
 }
 
 // Convert name to number.
@@ -547,7 +839,7 @@ func getArch(arch string) (string, uint32, error) {
 		}
 
 		switch runtimeArch {
-		case "aarch64", "x86_64", "ppc":
+		case "aarch64", "x86_64", "ppc64":
 			realArch = runtimeArch
 		default:
 			return "", 0, errors.Errorf("cannot use b64 on %v", runtimeArch)
@@ -565,6 +857,8 @@ func getArch(arch string) (string, uint32, error) {
 			realArch = "arm"
 		case "x86_64":
 			realArch = "i386"
+		case "ppc64":
+			realArch = "ppc"
 		default:
 			return "", 0, errors.Errorf("cannot use b32 on %v", runtimeArch)
 		}
@@ -575,6 +869,40 @@ func getArch(arch string) (string, uint32, error) {
 		return "", 0, errors.Errorf("unknown arch '%v'", arch)
 	}
 	return realArch, archValue, nil
+}
+
+// from a rule arch returned by kernel, decide what arch name to display
+func getDisplayArch(archId uint32) (string, error) {
+	runtimeArchStr, err := getRuntimeArch()
+	if err != nil {
+		return "", err
+	}
+	runtimeArchU32, ok := reverseArch[runtimeArchStr]
+	if !ok {
+		return "", errors.New("current architecture not supported")
+	}
+	runtimeArch := auparse.AuditArch(runtimeArchU32)
+	requestedArch := auparse.AuditArch(archId)
+	if requestedArch == runtimeArch {
+		switch requestedArch {
+		case auparse.AUDIT_ARCH_AARCH64, auparse.AUDIT_ARCH_X86_64, auparse.AUDIT_ARCH_PPC64:
+			return "b64", nil
+		case auparse.AUDIT_ARCH_ARM, auparse.AUDIT_ARCH_I386, auparse.AUDIT_ARCH_PPC:
+			return "b32", nil
+		}
+	} else {
+		switch {
+		case runtimeArch == auparse.AUDIT_ARCH_AARCH64 && requestedArch == auparse.AUDIT_ARCH_ARM,
+			runtimeArch == auparse.AUDIT_ARCH_X86_64 && requestedArch == auparse.AUDIT_ARCH_I386,
+			runtimeArch == auparse.AUDIT_ARCH_PPC64 && requestedArch == auparse.AUDIT_ARCH_PPC:
+			return "b32", nil
+		}
+	}
+	name, ok := auparse.AuditArchNames[requestedArch]
+	if !ok {
+		return "", fmt.Errorf("unsupported arch=%x in rule", requestedArch)
+	}
+	return name, nil
 }
 
 // getRuntimeArch returns the program's arch (not the machine's arch).
@@ -589,8 +917,8 @@ func getRuntimeArch() (string, error) {
 		arch = "i386"
 	case "amd64":
 		arch = "x86_64"
-	case "ppc64", "ppc64le":
-		arch = "ppc"
+	case "ppc64", "ppc64le", "ppc":
+		arch = runtime.GOARCH
 	case "s390":
 		arch = "s390"
 	case "s390x":
@@ -641,6 +969,24 @@ func getPerm(perm string) (uint32, error) {
 	return uint32(permBits), nil
 }
 
+// String returns the string representation of the permission bits.
+func (bits permission) String() string {
+	perms := make([]byte, 0, 4)
+	if bits&readPerm != 0 {
+		perms = append(perms, 'r')
+	}
+	if bits&writePerm != 0 {
+		perms = append(perms, 'w')
+	}
+	if bits&execPerm != 0 {
+		perms = append(perms, 'x')
+	}
+	if bits&attrPerm != 0 {
+		perms = append(perms, 'a')
+	}
+	return string(perms)
+}
+
 func getFiletype(filetype string) (filetype, error) {
 	switch strings.ToLower(filetype) {
 	case "file":
@@ -659,6 +1005,28 @@ func getFiletype(filetype string) (filetype, error) {
 		return fifoFiletype, nil
 	default:
 		return 0, errors.Errorf("invalid filetype '%v'", filetype)
+	}
+}
+
+// String returns the string representation of a filetype
+func (ft filetype) String() string {
+	switch ft {
+	case fileFiletype:
+		return "file"
+	case dirFiletype:
+		return "dir"
+	case socketFiletype:
+		return "socket"
+	case linkFiletype:
+		return "symlink"
+	case characterFiletype:
+		return "char"
+	case blockFiletype:
+		return "block"
+	case fifoFiletype:
+		return "fifo"
+	default:
+		return fmt.Sprintf("UNKNOWN:%x", uint32(ft))
 	}
 }
 

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -58,50 +58,50 @@ func TestBuild(t *testing.T) {
 func TestAddFlag(t *testing.T) {
 	t.Run("exit", func(t *testing.T) {
 		rule := &ruleData{}
-		assert.NoError(t, addList(rule, "exit"))
+		assert.NoError(t, rule.setList("exit"))
 		assert.EqualValues(t, exitFilter, rule.flags)
 	})
 
 	t.Run("task", func(t *testing.T) {
 		rule := &ruleData{}
-		assert.NoError(t, addList(rule, "task"))
+		assert.NoError(t, rule.setList("task"))
 		assert.EqualValues(t, taskFilter, rule.flags)
 	})
 
 	t.Run("user", func(t *testing.T) {
 		rule := &ruleData{}
-		assert.NoError(t, addList(rule, "user"))
+		assert.NoError(t, rule.setList("user"))
 		assert.EqualValues(t, userFilter, rule.flags)
 	})
 
 	t.Run("exclude", func(t *testing.T) {
 		rule := &ruleData{}
-		assert.NoError(t, addList(rule, "exclude"))
+		assert.NoError(t, rule.setList("exclude"))
 		assert.EqualValues(t, excludeFilter, rule.flags)
 	})
 
 	t.Run("invalid", func(t *testing.T) {
 		rule := &ruleData{}
-		assert.Error(t, addList(rule, "invalid"))
+		assert.Error(t, rule.setList("invalid"))
 	})
 }
 
 func TestAddAction(t *testing.T) {
 	t.Run("always", func(t *testing.T) {
 		rule := &ruleData{}
-		assert.NoError(t, addAction(rule, "always"))
+		assert.NoError(t, rule.setAction("always"))
 		assert.EqualValues(t, alwaysAction, rule.action)
 	})
 
 	t.Run("never", func(t *testing.T) {
 		rule := &ruleData{}
-		assert.NoError(t, addAction(rule, "never"))
+		assert.NoError(t, rule.setAction("never"))
 		assert.EqualValues(t, neverAction, rule.action)
 	})
 
 	t.Run("invalid", func(t *testing.T) {
 		rule := &ruleData{}
-		assert.Error(t, addAction(rule, "invalid"))
+		assert.Error(t, rule.setAction("invalid"))
 	})
 }
 

--- a/rule/tables.go
+++ b/rule/tables.go
@@ -20,13 +20,19 @@ package rule
 import "github.com/elastic/go-libaudit/auparse"
 
 var (
-	reverseSyscall map[string]map[string]int
-	reverseArch    map[string]uint32
+	reverseSyscall          map[string]map[string]int
+	reverseArch             map[string]uint32
+	reverseOperatorsTable   map[operator]string
+	reverseFieldsTable      map[field]string
+	reverseComparisonsTable map[comparison][2]field
 )
 
 func init() {
 	buildReverseSyscallTable()
 	buildReverseArchTable()
+	buildReverseOperatorsTable()
+	buildReverseFieldsTable()
+	buildReverseComparisonsTable()
 }
 
 func buildReverseSyscallTable() {
@@ -47,6 +53,31 @@ func buildReverseArchTable() {
 
 	for arch, name := range auparse.AuditArchNames {
 		reverseArch[name] = uint32(arch)
+	}
+}
+
+func buildReverseOperatorsTable() {
+	reverseOperatorsTable = make(map[operator]string, len(operatorsTable))
+	for k, v := range operatorsTable {
+		reverseOperatorsTable[v] = k
+	}
+}
+
+func buildReverseFieldsTable() {
+	reverseFieldsTable = make(map[field]string, len(fieldsTable))
+	for k, v := range fieldsTable {
+		reverseFieldsTable[v] = k
+	}
+}
+
+func buildReverseComparisonsTable() {
+	reverseComparisonsTable = make(map[comparison][2]field, len(comparisonsTable))
+	for lhs, table := range comparisonsTable {
+		for rhs, comp := range table {
+			if _, found := reverseComparisonsTable[comp]; !found {
+				reverseComparisonsTable[comp] = [2]field{lhs, rhs}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Added a new method to the rule package, `ToCommandLine`, that takes the binary representation of a rule from the kernel (WireFormat) and returns the textual representation of this rule as a command-line argument.

It mimics the output of `auditctl -l` with a few exceptions:
- By default, UIDs, GIDs and filetype fields are converted to a textual representation (i.e. `root` for gid=0). This can be toggled with an argument flag.
- The implementation of auditctl used for testing this feature displayed any architecture either as `b64` or `b32`, so it's not possible to tell if a rule has the right architecture or not. This implementation will print architectures different than the one it is running in their full form, for example `aarch64` when running under `x86_64`.