### PR TITLE
Fixes to rule conversion into display format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   find . -name '*.go' | grep -v vendor | xargs gofmt -s -l | read &&
   echo "Code differs from gofmt's style. Run 'gofmt -s -w .'" 1>&2 && exit 1 || true
 - go test -v $(go list ./... | grep -v /vendor/)
+- GOARCH=386 go test -v $(go list ./... | grep -v /vendor/)
 - mkdir -p build/bin
 - go build -o build/bin/audit ./cmd/audit/
 - go build -o build/bin/auparse ./cmd/auparse/

--- a/audit_test.go
+++ b/audit_test.go
@@ -637,6 +637,9 @@ func TestAuditClientSetBacklogWaitTime(t *testing.T) {
 	}
 
 	status, err := getStatus(t)
+	if err != nil || status == nil {
+		t.Skipf("audit status not available: %v", err)
+	}
 	if status.FeatureBitmap&AuditFeatureBitmapBacklogWaitTime == 0 {
 		t.Skip("backlog wait time feature not supported in current kernel")
 	}

--- a/audit_test.go
+++ b/audit_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -738,22 +739,63 @@ func TestAuditClientGetStatusAsync(t *testing.T) {
 }
 
 func TestRuleParsing(t *testing.T) {
-	for idx, line := range []string{
-		"-a always,exit -F arch=b64 -S execve,execveat -F key=exec",
-		"-a never,exit -F arch=b64 -S connect,accept,bind -F key=external-access",
-		"-w /etc/group -p wa",
-		"-w /etc/passwd -p rx",
-		"-w /etc/gshadow -p rwxa",
-		"-w /tmp/test -p rwa",
-		"-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F key=access",
-		"-a never,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F key=access",
-		"-a always,exit -F arch=b32 -S open -F key=admin -F uid=root -F gid=root -F exit=33 -F path=/tmp -F perm=rwxa",
-		"-a always,exit -F arch=b64 -S open -F key=key -F uid=1111 -F gid=333 -F exit=-151111 -F filetype=fifo",
-		"-a never,exclude -F msgtype=GRP_CHAUTHTOK",
-		"-a always,user -F uid=root",
-		"-a always,task -F uid=root",
-		"-a always,exit -S mount -F pid=1234",
-	} {
+	var rules []string
+	switch runtime.GOARCH {
+	case "386":
+		rules = []string{
+			"-a always,exit -F arch=b32 -S execve,execveat -F key=exec",
+			"-a never,exit -F arch=b32 -S bind,connect,accept4 -F key=external-access",
+			"-w /etc/group -p wa",
+			"-w /etc/passwd -p rx",
+			"-w /etc/gshadow -p rwxa",
+			"-w /tmp/test -p rwa",
+			"-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F key=access",
+			"-a never,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F key=access",
+			"-a always,exit -F arch=b32 -S open -F key=admin -F uid=root -F gid=root -F exit=33 -F path=/tmp -F perm=rwxa",
+			"-a always,exit -F arch=b32 -S open -F key=key -F uid=1111 -F gid=333 -F exit=-151111 -F filetype=fifo",
+			"-a never,exclude -F msgtype=GRP_CHAUTHTOK",
+			"-a always,user -F uid=root",
+			"-a always,task -F uid=root",
+			"-a always,exit -S mount -F pid=1234",
+		}
+	case "amd64":
+		rules = []string{
+			"-a always,exit -F arch=b64 -S execve,execveat -F key=exec",
+			"-a never,exit -F arch=b64 -S connect,accept,bind -F key=external-access",
+			"-w /etc/group -p wa",
+			"-w /etc/passwd -p rx",
+			"-w /etc/gshadow -p rwxa",
+			"-w /tmp/test -p rwa",
+			"-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F key=access",
+			"-a never,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F key=access",
+			"-a always,exit -F arch=b32 -S open -F key=admin -F uid=root -F gid=root -F exit=33 -F path=/tmp -F perm=rwxa",
+			"-a always,exit -F arch=b64 -S open -F key=key -F uid=1111 -F gid=333 -F exit=-151111 -F filetype=fifo",
+			"-a never,exclude -F msgtype=GRP_CHAUTHTOK",
+			"-a always,user -F uid=root",
+			"-a always,task -F uid=root",
+			"-a always,exit -S mount -F pid=1234",
+		}
+	default:
+		// Can't have multiple syscall testing as ordering of individual syscalls
+		// will vary between platforms (sorted by syscall id)
+		rules = []string{
+			"-a always,exit -S execve -F key=exec",
+			"-w /etc/group -p wa",
+			"-w /etc/passwd -p rx",
+			"-w /etc/gshadow -p rwxa",
+			"-w /tmp/test -p rwa",
+			"-a always,exit -S all -F exit=-EACCES -F key=access",
+			"-a never,exit -S all -F exit=-EPERM -F key=access",
+			"-a always,exit -S open -F key=admin -F uid=root -F gid=root -F exit=33 -F path=/tmp -F perm=rwxa",
+			"-a always,exit -S open -F key=key -F uid=1111 -F gid=333 -F exit=-151111 -F filetype=fifo",
+			"-a never,exclude -F msgtype=GRP_CHAUTHTOK",
+			"-a always,user -F uid=root",
+			"-a always,task -F uid=root",
+			"-a always,exit -S mount -F pid=1234",
+		}
+	}
+	t.Logf("checking %d rules", len(rules))
+	for idx, line := range rules {
 		msg := fmt.Sprintf("parsing line #%d: `%s`", idx, line)
 		r, err := flags.Parse(line)
 		if err != nil {

--- a/audit_test.go
+++ b/audit_test.go
@@ -749,6 +749,7 @@ func TestRuleParsing(t *testing.T) {
 		"-a never,exclude -F msgtype=GRP_CHAUTHTOK",
 		"-a always,user -F uid=root",
 		"-a always,task -F uid=root",
+		"-a always,exit -S mount -F pid=1234",
 	} {
 		msg := fmt.Sprintf("parsing line #%d: `%s`", idx, line)
 		r, err := flags.Parse(line)

--- a/reassembler_test.go
+++ b/reassembler_test.go
@@ -96,7 +96,7 @@ func TestReassembler(t *testing.T) {
 }
 
 type eventMeta struct {
-	seq   int
+	seq   uint
 	count int
 }
 

--- a/rule/gen_testdata_test.go
+++ b/rule/gen_testdata_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build linux
+// +build linux,amd64
 
 package rule_test
 

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -197,6 +197,7 @@ func ToCommandLine(wf WireFormat, resolveIds bool) (rule string, err error) {
 		}
 		if r.arch == "b32" {
 			switch arch {
+			case "i386", "arm", "ppc":
 			case "aarch64":
 				arch = "arm"
 			case "x86_64":
@@ -204,7 +205,7 @@ func ToCommandLine(wf WireFormat, resolveIds bool) (rule string, err error) {
 			case "ppc64", "ppc64le":
 				arch = "ppc"
 			default:
-				return "", errors.New("invalid arch for b32")
+				return "", fmt.Errorf("invalid arch for b32: '%s'", arch)
 			}
 		} else if len(r.arch) > 0 && r.arch != "b64" {
 			arch = r.arch

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -206,7 +206,7 @@ func ToCommandLine(wf WireFormat, resolveIds bool) (rule string, err error) {
 			default:
 				return "", errors.New("invalid arch for b32")
 			}
-		} else if r.arch != "b64" {
+		} else if len(r.arch) > 0 && r.arch != "b64" {
 			arch = r.arch
 		}
 		syscallTable, ok := auparse.AuditSyscalls[arch]

--- a/rule/rule_integ_test.go
+++ b/rule/rule_integ_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,amd64
+
 package rule_test
 
 import (

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -362,7 +362,7 @@ func TestAddFilter(t *testing.T) {
 		}
 		assert.EqualValues(t, arg3Field, rule.fields[0])
 		assert.EqualValues(t, equalOperator, rule.fieldFlags[0])
-		assert.EqualValues(t, math.MaxUint32, rule.values[0])
+		assert.EqualValues(t, uint32(math.MaxUint32), rule.values[0])
 	})
 
 	t.Run("arg_min_int32", func(t *testing.T) {


### PR DESCRIPTION
Some fixes for the `rule.ToCommandline` feature:

- Fix parsing of syscall rules when arch was not specified.
- Feature was broken under 32bit platforms
- Some tests fixes for 32bit