### PR TITLE
Make ID lookups thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- aucoalesce - Made the user/group ID cache thread-safe. #42
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
Concurrent calls to aucoalesce.ResolveIDs() caused panics due to concurrent map writes.