### PR TITLE
auparse: Fix computation of message offsets

### DIFF
--- a/auparse/auparse.go
+++ b/auparse/auparse.go
@@ -185,7 +185,7 @@ func Parse(typ AuditMessageType, message string) (*AuditMessage, error) {
 		RecordType: typ,
 		Timestamp:  timestamp,
 		Sequence:   seq,
-		offset:     indexOfMessage(message[end:]),
+		offset:     end + indexOfMessage(message[end:]),
 		RawData:    message,
 	}
 	return msg, nil
@@ -232,17 +232,12 @@ func parseAuditHeader(line []byte) (time.Time, uint32, int, error) {
 		return time.Time{}, 0, 0, errInvalidAuditHeader
 	}
 
-	return tm, uint32(sequence), end, nil
+	return tm, uint32(sequence), end + 1, nil
 }
 
 func indexOfMessage(msg string) int {
 	return strings.IndexFunc(msg, func(r rune) bool {
-		switch r {
-		case ':', ' ':
-			return true
-		default:
-			return false
-		}
+		return r != ':' && r != ' '
 	})
 }
 

--- a/auparse/auparse_test.go
+++ b/auparse/auparse_test.go
@@ -46,6 +46,12 @@ const (
 	syscallLogLine = `type=SYSCALL msg=` + syscallMsg
 )
 
+func TestParseMessageOffset(t *testing.T) {
+	msg, err := Parse(AUDIT_SYSCALL, syscallMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, msg.offset, len("audit(1490137971.011:50406): "))
+}
+
 func TestNormalizeAuditMessage(t *testing.T) {
 	tests := []struct {
 		typ AuditMessageType
@@ -79,7 +85,7 @@ func TestParseAuditHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.EqualValues(t, ')', syscallMsg[end])
+	assert.EqualValues(t, ')', syscallMsg[end-1])
 	assert.Equal(t, time.Unix(1490137971, 11*int64(time.Millisecond)).UnixNano(), ts.UnixNano())
 	assert.EqualValues(t, 50406, seq)
 }


### PR DESCRIPTION
The `AuditMessage.offset` generated by `auparse.Parse` is completely bogus right now, and always the value `2` regardless of the size of the header. While it doesn't actually matter in practice (because the k/v parsing regexp ends up ignoring the bogus data) it seems worth fixing.