### PR TITLE
Remove linux build flag

### DIFF
--- a/sys/endian.go
+++ b/sys/endian.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build linux
-
 package sys
 
 import (


### PR DESCRIPTION
The build flag is unnecessary since all this subpackage is doing is a runtime byte endianness check. Having this flag actually breaks compilation of this library due to the subpackage not having any files on non-linux systems. As seen in an upstream `beats` build:

> [2020-05-15T20:40:38.689Z] build github.com/elastic/go-libaudit/v2/sys: cannot load github.com/elastic/go-libaudit/v2/sys: no Go source files

The alternative is gating every place where we import this subpackage with a `linux` build flag and then providing alternate implementations for non-linux platforms with some default error returns... this is simpler.