### PR TITLE
Fix typo in event.action for AUDIT_ROLE_REMOVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added support for big endian. #48
 - Added semantic versioning support via go modules. #61
-- Add ECS categorization support for events by record type and syscall. #62
+- Added ECS categorization support for events by record type and syscall. #62
+- Fixed a typo in the action value associated with ROLE_REMOVE messages. #65
 
 ### Removed
 

--- a/aucoalesce/normalizations.yaml
+++ b/aucoalesce/normalizations.yaml
@@ -914,7 +914,7 @@ normalizations:
         - change
   # AUDIT_ROLE_REMOVE - Admin removed user from role
   - record_types: ROLE_REMOVE
-    action: removed-use-role-from
+    action: removed-user-role-from
     object:
       primary: [id, acct]
       what: account


### PR DESCRIPTION
This fixes a typo in `removed-use-role-from` to `removed-user-role-from`.

Closes #54