### PR TITLE
Fix anomaly spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for big endian. #48
 - Added semantic versioning support via go modules. #61
 - Add ECS categorization support for events by record type and syscall. #62
+- Fixed spelling of anomaly in aucoalesce package. #67
 
 ### Removed
 

--- a/aucoalesce/event_type.go
+++ b/aucoalesce/event_type.go
@@ -34,9 +34,9 @@ const (
 	EventTypeUserLogin
 	EventTypeAuditDaemon
 	EventTypeMACDecision
-	EventTypeAnomoly
+	EventTypeAnomaly
 	EventTypeIntegrity
-	EventTypeAnomolyResponse
+	EventTypeAnomalyResponse
 	EventTypeMAC
 	EventTypeCrypto
 	EventTypeVirt
@@ -55,9 +55,9 @@ var auditEventTypeNames = map[AuditEventType]string{
 	EventTypeUserLogin:       "user-login",
 	EventTypeAuditDaemon:     "audit-daemon",
 	EventTypeMACDecision:     "mac-decision",
-	EventTypeAnomoly:         "anomoly",
+	EventTypeAnomaly:         "anomaly",
 	EventTypeIntegrity:       "integrity",
-	EventTypeAnomolyResponse: "anomaly-response",
+	EventTypeAnomalyResponse: "anomaly-response",
 	EventTypeMAC:             "mac",
 	EventTypeCrypto:          "crypto",
 	EventTypeVirt:            "virt",
@@ -120,9 +120,9 @@ func GetAuditEventType(t AuditMessageType) AuditEventType {
 	case t >= AUDIT_ANOM_PROMISCUOUS && t <= AUDIT_LAST_KERN_ANOM_MSG,
 		t >= AUDIT_ANOM_LOGIN_FAILURES && t <= AUDIT_ANOM_RBAC_FAIL,
 		t >= AUDIT_ANOM_CRYPTO_FAIL && t <= AUDIT_LAST_ANOM_MSG:
-		return EventTypeAnomoly
+		return EventTypeAnomaly
 	case t >= AUDIT_RESP_ANOMALY && t <= AUDIT_LAST_ANOM_RESP:
-		return EventTypeAnomolyResponse
+		return EventTypeAnomalyResponse
 	case t >= AUDIT_MAC_POLICY_LOAD && t <= AUDIT_LAST_SELINUX,
 		t >= AUDIT_AA && t <= AUDIT_APPARMOR_AUDIT,
 		t >= AUDIT_APPARMOR_HINT && t <= AUDIT_APPARMOR_STATUS,

--- a/aucoalesce/testdata/random-internet.json.golden
+++ b/aucoalesce/testdata/random-internet.json.golden
@@ -4,7 +4,7 @@
     "event": {
       "@timestamp": "2015-02-06T15:03:14.398Z",
       "sequence": 911150,
-      "category": "anomoly",
+      "category": "anomaly",
       "record_type": "anom_abend",
       "result": "unknown",
       "session": "unset",

--- a/aucoalesce/testdata/ubuntu-16.10-linux-4.8.0.json.golden
+++ b/aucoalesce/testdata/ubuntu-16.10-linux-4.8.0.json.golden
@@ -4,7 +4,7 @@
     "event": {
       "@timestamp": "2017-04-21T00:32:22.981Z",
       "sequence": 753,
-      "category": "anomoly",
+      "category": "anomaly",
       "record_type": "anom_promiscuous",
       "result": "success",
       "session": "1",


### PR DESCRIPTION
This fixes the spelling of anomaly (misspelled as "anomoly") is several places.

Two constants in Go were changed

- aucoalesce.EventTypeAnomaly
- aucoalesce.EventTypeAnomalyResponse

And the names associated with those constants where changed (affect "category" values in events)

- "anomaly"
- "anomaly-response"

Fixes #49