### PR TITLE
Add SetImmutable to audit client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for big endian. #48
 - Added semantic versioning support via go modules. #61
 - Add ECS categorization support for events by record type and syscall. #62
+- Added `SetImmutable` to the audit client for marking the audit settings
+  as immutable within the kernel. #55 #68
 
 ### Removed
 

--- a/audit.go
+++ b/audit.go
@@ -364,6 +364,19 @@ func (c *AuditClient) SetEnabled(enabled bool, wm WaitMode) error {
 	return c.set(status, wm)
 }
 
+// SetImmutable is used to lock the audit configuration so that it can't be
+// changed. Locking the configuration is intended to be the last command you
+// issue. Any attempt to change the configuration in this mode will be
+// audited and denied. The configuration can only be changed by rebooting the
+// machine.
+func (c *AuditClient) SetImmutable(wm WaitMode) error {
+	status := AuditStatus{
+		Mask:    AuditStatusEnabled,
+		Enabled: 2,
+	}
+	return c.set(status, wm)
+}
+
 // SetFailure sets the action that the kernel will perform when the backlog
 // limit is reached or when it encounters an error and cannot proceed.
 func (c *AuditClient) SetFailure(fm FailureMode, wm WaitMode) error {
@@ -587,7 +600,7 @@ var sizeofAuditStatus = int(unsafe.Sizeof(AuditStatus{}))
 // https://github.com/linux-audit/audit-kernel/blob/v4.7/include/uapi/linux/audit.h#L413-L427
 type AuditStatus struct {
 	Mask            AuditStatusMask // Bit mask for valid entries.
-	Enabled         uint32          // 1 = enabled, 0 = disabled
+	Enabled         uint32          // 1 = enabled, 0 = disabled, 2 = immutable
 	Failure         uint32          // Failure-to-log action.
 	PID             uint32          // PID of auditd process.
 	RateLimit       uint32          // Messages rate limit (per second).

--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -42,6 +42,7 @@ var (
 	diag        = fs.String("diag", "", "dump raw information from kernel to file")
 	rate        = fs.Uint("rate", 0, "rate limit in kernel (default 0, no rate limit)")
 	backlog     = fs.Uint("backlog", 8192, "backlog limit")
+	immutable   = fs.Bool("immutable", false, "make kernel audit settings immutable (requires reboot to undo)")
 	receiveOnly = fs.Bool("ro", false, "receive only using multicast, requires kernel 3.16+")
 )
 
@@ -125,6 +126,13 @@ func read() error {
 			log.Debugf("setting backlog limit in kernel to %v", *backlog)
 			if err = client.SetBacklogLimit(uint32(*backlog), libaudit.NoWait); err != nil {
 				return errors.Wrap(err, "failed to set backlog limit")
+			}
+		}
+
+		if status.Enabled != 2 {
+			log.Debugf("setting kernel settings as immutable")
+			if err = client.SetImmutable(libaudit.NoWait); err != nil {
+				return errors.Wrap(err, "failed to set kernel as immutable")
 			}
 		}
 


### PR DESCRIPTION
SetImmutable is used to lock the audit configuration so that it can't be
changed. Locking the configuration is intended to be the last command you
issue. Any attempt to change the configuration in this mode will be
audited and denied. The configuration can only be changed by rebooting the
machine.

Closes #55