### PR TITLE
Improve perfomance through static error values

### DIFF
--- a/auparse/auparse_test.go
+++ b/auparse/auparse_test.go
@@ -361,5 +361,99 @@ func ExampleParseLogLine() {
 	//   "syscall": "connect",
 	//   "tty": "(none)",
 	//   "uid": "0"
-	//}
+	// }
+}
+
+func BenchmarkAuditMessage_Data(b *testing.B) {
+	m := &AuditMessage{
+		offset: -1,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Data()
+	}
+}
+
+func Benchmark_arch(b *testing.B) {
+	d := map[string]*field{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		arch(d)
+	}
+}
+
+func Benchmark_setSyscallName(b *testing.B) {
+	d := map[string]*field{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		setSyscallName(d)
+	}
+}
+
+func Benchmark_setSyscallNameArchKey(b *testing.B) {
+	d := map[string]*field{
+		"syscall": {"1", "1"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		setSyscallName(d)
+	}
+}
+
+func Benchmark_setSignalName(b *testing.B) {
+	d := map[string]*field{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		setSignalName(d)
+	}
+}
+
+func Benchmark_saddr(b *testing.B) {
+	d := map[string]*field{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		saddr(d)
+	}
+}
+
+func Benchmark_execveArgs(b *testing.B) {
+	d := map[string]*field{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		execveArgs(d)
+	}
+}
+
+func Benchmark_result(b *testing.B) {
+	d := map[string]*field{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result(d)
+	}
+}
+
+func Benchmark_exit(b *testing.B) {
+	d := map[string]*field{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		exit(d)
+	}
 }


### PR DESCRIPTION
I suggest replacing all errors from creating in methods to global variables. It will spend less time generating errors per each event. You can see improving speed below

```
BenchmarkAuditMessage_Data                  402343958   2.955 ns/op     0 B/op	    0 allocs/op
BenchmarkAuditMessage_DataConstErr          411572781   2.867 ns/op     0 B/op	    0 allocs/op
Benchmark_arch                              1342098	874.1 ns/op	304 B/op    3 allocs/op
Benchmark_archConst                         318288404   3.815 ns/op	0 B/op	    0 allocs/op
Benchmark_setSyscallName                    1222840	965.4 ns/op	304 B/op    3 allocs/op
Benchmark_setSyscallNameArchKey             1362066	859.5 ns/op	304 B/op    3 allocs/op
Benchmark_setSyscallNameConstErr            274332856   3.751 ns/op	0 B/op	    0 allocs/op
Benchmark_setSyscallConstErrNameArchKey     83698242    15.32 ns/op	0 B/op	    0 allocs/op
Benchmark_setSignalName                     1399560	884.4 ns/op	304 B/op    3 allocs/op
Benchmark_setSignalNameConstErr             318109981   3.749 ns/op	0 B/op	    0 allocs/op
Benchmark_saddr                             1289529	880.5 ns/op	304 B/op    3 allocs/op
Benchmark_saddrConstErr                     298823174   3.888 ns/op	0 B/op	    0 allocs/op
Benchmark_execveArgs                        1264544	917.5 ns/op	304 B/op    3 allocs/op
Benchmark_execveArgsConstErr                284703768   4.075 ns/op	0 B/op	    0 allocs/op
Benchmark_result                            1217290	981.5 ns/op	304 B/op    3 allocs/op
Benchmark_resultConstErr                    168506590   6.961 ns/op	0 B/op	    0 allocs/op
Benchmark_exit                              1239430	970.8 ns/op	304 B/op    3 allocs/op
Benchmark_exitConstErr                      289456666   4.095 ns/op	0 B/op	    0 allocs/op
```
