### PR TITLE
rework extractKeyValuePairs to use custom parser instead of regexp

### DIFF
--- a/auparse/auparse.go
+++ b/auparse/auparse.go
@@ -308,11 +308,11 @@ func saveKeyValue(key, origValue, value string, data map[string]*field) {
 func extractKeyValuePairs(msg string, data map[string]*field) {
 	type parseState int
 	const (
-		skipState        parseState = iota
-		keyState         parseState = iota
-		valueBeginState  parseState = iota
-		plainValueState  parseState = iota
-		quotedValueState parseState = iota
+		skipState parseState = iota
+		keyState
+		valueBeginState
+		plainValueState
+		quotedValueState
 	)
 	state := skipState
 	var keyStart, valueStart int


### PR DESCRIPTION
new benchmarks for current code:

Benchmark_extractKeyValuePairs-4   	  116500	     10015 ns/op	    1301 B/op	      31 allocs/op
BenchmarkParseLogLineFromFiles-4   	     366	   3287822 ns/op	  520184 B/op	    7324 allocs/op
new benchmarks for new parsing code:

Benchmark_extractKeyValuePairs-4   	 1000000	      1093 ns/op	     192 B/op	       6 allocs/op
BenchmarkParseLogLineFromFiles-4   	     770	   1506856 ns/op	  330313 B/op	    3389 allocs/op
So, extractKeyValuePairs is ~10x faster, and overall parser flow is ~2x faster.