### PR TITLE
Simplify message serialisation code and test

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -598,8 +598,10 @@ type AuditStatus struct {
 	BacklogWaitTimeActual uint32          // Time the kernel has spent waiting while the backlog limit is exceeded.
 }
 
+const sizeofAuditStatus = int(unsafe.Sizeof(AuditStatus{}))
+
 func (s AuditStatus) toWireFormat() []byte {
-	return (*[unsafe.Sizeof(AuditStatus{})]byte)(unsafe.Pointer(&s))[:]
+	return (*[sizeofAuditStatus]byte)(unsafe.Pointer(&s))[:]
 }
 
 // FromWireFormat unmarshals the given buffer to an AuditStatus object. Due to
@@ -607,7 +609,7 @@ func (s AuditStatus) toWireFormat() []byte {
 // not return an error if the buffer is smaller than the sizeof our AuditStatus
 // struct.
 func (s *AuditStatus) FromWireFormat(buf []byte) error {
-	if len(buf) < int(unsafe.Sizeof(AuditStatus{})) {
+	if len(buf) < sizeofAuditStatus {
 		return io.ErrUnexpectedEOF
 	}
 	copy((*[unsafe.Sizeof(AuditStatus{})]byte)(unsafe.Pointer(s))[:], buf)

--- a/audit.go
+++ b/audit.go
@@ -20,8 +20,6 @@
 package libaudit
 
 import (
-	"bytes"
-	"encoding/binary"
 	"io"
 	"os"
 	"sync"
@@ -32,11 +30,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/go-libaudit/v2/auparse"
-	"github.com/elastic/go-libaudit/v2/sys"
-)
-
-var (
-	byteOrder = sys.GetEndian()
 )
 
 const (
@@ -167,7 +160,7 @@ func (c *AuditClient) GetStatus() (*AuditStatus, error) {
 // GetStatusAsync sends a request for the status of the kernel's audit subsystem
 // and returns without waiting for a response.
 func (c *AuditClient) GetStatusAsync(requireACK bool) (seq uint32, err error) {
-	var flags uint16 = syscall.NLM_F_REQUEST
+	flags := uint16(syscall.NLM_F_REQUEST)
 	if requireACK {
 		flags |= syscall.NLM_F_ACK
 	}
@@ -552,15 +545,10 @@ func parseNetlinkAuditMessage(buf []byte) ([]syscall.NetlinkMessage, error) {
 	if len(buf) < syscall.NLMSG_HDRLEN {
 		return nil, syscall.EINVAL
 	}
-
-	r := bytes.NewReader(buf)
-	m := syscall.NetlinkMessage{}
-	if err := binary.Read(r, byteOrder, &m.Header); err != nil {
-		return nil, err
-	}
-	m.Data = buf[syscall.NLMSG_HDRLEN:]
-
-	return []syscall.NetlinkMessage{m}, nil
+	return []syscall.NetlinkMessage{{
+		Header: *(*syscall.NlMsghdr)(unsafe.Pointer(&buf[0])),
+		Data:   buf[syscall.NLMSG_HDRLEN:],
+	}}, nil
 }
 
 // audit_status message
@@ -593,8 +581,6 @@ const (
 	AuditFeatureBitmapLostReset
 )
 
-var sizeofAuditStatus = int(unsafe.Sizeof(AuditStatus{}))
-
 // AuditStatus is a status message and command and control message exchanged
 // between the kernel and user-space.
 // https://github.com/linux-audit/audit-kernel/blob/v5.9/include/uapi/linux/audit.h#L457-L474
@@ -613,13 +599,7 @@ type AuditStatus struct {
 }
 
 func (s AuditStatus) toWireFormat() []byte {
-	buf := bytes.NewBuffer(make([]byte, sizeofAuditStatus))
-	buf.Reset()
-	if err := binary.Write(buf, byteOrder, s); err != nil {
-		// This never returns an error.
-		panic(err)
-	}
-	return buf.Bytes()
+	return (*[unsafe.Sizeof(AuditStatus{})]byte)(unsafe.Pointer(&s))[:]
 }
 
 // FromWireFormat unmarshals the given buffer to an AuditStatus object. Due to
@@ -627,35 +607,10 @@ func (s AuditStatus) toWireFormat() []byte {
 // not return an error if the buffer is smaller than the sizeof our AuditStatus
 // struct.
 func (s *AuditStatus) FromWireFormat(buf []byte) error {
-	fields := []interface{}{
-		&s.Mask,
-		&s.Enabled,
-		&s.Failure,
-		&s.PID,
-		&s.RateLimit,
-		&s.BacklogLimit,
-		&s.Lost,
-		&s.Backlog,
-		&s.FeatureBitmap,
-		&s.BacklogWaitTime,
-		&s.BacklogWaitTimeActual,
+	if len(buf) < int(unsafe.Sizeof(AuditStatus{})) {
+		return io.ErrUnexpectedEOF
 	}
-
-	if len(buf) == 0 {
-		return io.EOF
-	}
-
-	r := bytes.NewReader(buf)
-	for _, f := range fields {
-		if r.Len() == 0 {
-			return nil
-		}
-
-		if err := binary.Read(r, byteOrder, f); err != nil {
-			return err
-		}
-	}
-
+	copy((*[unsafe.Sizeof(AuditStatus{})]byte)(unsafe.Pointer(s))[:], buf)
 	return nil
 }
 

--- a/audit_test.go
+++ b/audit_test.go
@@ -30,6 +30,7 @@ import (
 	"runtime"
 	"syscall"
 	"testing"
+	"testing/quick"
 	"time"
 
 	"github.com/pkg/errors"
@@ -747,6 +748,20 @@ func TestAuditClientGetStatusAsync(t *testing.T) {
 
 		t.Logf("Status: %+v", replyStatus)
 	}
+}
+
+func TestAuditStatusRoundTrip(t *testing.T) {
+	err := quick.Check(func(a AuditStatus) bool {
+		buf := a.toWireFormat()
+		var new AuditStatus
+		err := new.FromWireFormat(buf)
+		if err != nil {
+			t.Log(err)
+			return false
+		}
+		return a == new
+	}, nil)
+	assert.NoError(t, err, "audit status failed round-trip")
 }
 
 func TestAuditClientSetImmutable(t *testing.T) {

--- a/rule/binary.go
+++ b/rule/binary.go
@@ -36,6 +36,11 @@ type WireFormat []byte
 // AUDIT_LIST_RULES requests.
 // https://github.com/linux-audit/audit-kernel/blob/v3.15/include/uapi/linux/audit.h#L423-L437
 type auditRuleData struct {
+	auditRuleHeader
+	Buf []byte // String fields.
+}
+
+type auditRuleHeader struct {
 	Flags      filter
 	Action     action
 	FieldCount uint32
@@ -44,10 +49,9 @@ type auditRuleData struct {
 	Values     [maxFields]uint32
 	FieldFlags [maxFields]operator
 	BufLen     uint32 // Total length of buffer used for string fields.
-	Buf        []byte // String fields.
 }
 
-const ruleHeaderSize = int(unsafe.Sizeof(auditRuleData{}) - unsafe.Sizeof([]byte(nil)))
+const ruleHeaderSize = int(unsafe.Sizeof(auditRuleHeader{}))
 
 func (r auditRuleData) toWireFormat() WireFormat {
 	n := ruleHeaderSize + len(r.Buf)

--- a/rule/binary.go
+++ b/rule/binary.go
@@ -18,21 +18,14 @@
 package rule
 
 import (
-	"bytes"
-	"encoding/binary"
 	"io"
-
-	"github.com/pkg/errors"
-
-	"github.com/elastic/go-libaudit/v2/sys"
+	"unsafe"
 )
 
 const (
 	syscallBitmaskSize = 64 // AUDIT_BITMASK_SIZE
 	maxFields          = 64 // AUDIT_MAX_FIELDS
 )
-
-var endianness = sys.GetEndian()
 
 // WireFormat is the binary representation of a rule as used to exchange rules
 // (commands) with the kernel.
@@ -54,64 +47,27 @@ type auditRuleData struct {
 	Buf        []byte // String fields.
 }
 
+const ruleHeaderSize = int(unsafe.Sizeof(auditRuleData{}) - unsafe.Sizeof([]byte(nil)))
+
 func (r auditRuleData) toWireFormat() WireFormat {
-	out := new(bytes.Buffer)
-	binary.Write(out, endianness, r.Flags)
-	binary.Write(out, endianness, r.Action)
-	binary.Write(out, endianness, r.FieldCount)
-	binary.Write(out, endianness, r.Mask)
-	binary.Write(out, endianness, r.Fields)
-	binary.Write(out, endianness, r.Values)
-	binary.Write(out, endianness, r.FieldFlags)
-	binary.Write(out, endianness, r.BufLen)
-	out.Write(r.Buf)
-
-	// Adding padding.
-	if out.Len()%4 > 0 {
-		out.Write(make([]byte, 4-(out.Len()%4)))
-	}
-
-	return out.Bytes()
+	n := ruleHeaderSize + len(r.Buf)
+	n += (4 - n%4) % 4 // Adding padding.
+	buf := make([]byte, n)
+	copy(buf, (*[ruleHeaderSize]byte)(unsafe.Pointer(&r))[:])
+	copy(buf[ruleHeaderSize:], r.Buf)
+	return buf
 }
 
 func fromWireFormat(data WireFormat) (*auditRuleData, error) {
-	var partialRule struct {
-		Flags      filter
-		Action     action
-		FieldCount uint32
-		Mask       [syscallBitmaskSize]uint32
-		Fields     [maxFields]field
-		Values     [maxFields]uint32
-		FieldFlags [maxFields]operator
-		BufLen     uint32
-	}
-
-	reader := bytes.NewReader(data)
-	if err := binary.Read(reader, endianness, &partialRule); err != nil {
-		return nil, errors.Wrap(err, "deserialization of rule data failed")
-	}
-
-	rule := &auditRuleData{
-		Flags:      partialRule.Flags,
-		Action:     partialRule.Action,
-		FieldCount: partialRule.FieldCount,
-		Mask:       partialRule.Mask,
-		Fields:     partialRule.Fields,
-		Values:     partialRule.Values,
-		FieldFlags: partialRule.FieldFlags,
-		BufLen:     partialRule.BufLen,
-	}
-
-	if reader.Len() < int(rule.BufLen) {
+	if len(data) < ruleHeaderSize {
 		return nil, io.ErrUnexpectedEOF
 	}
-
-	if rule.BufLen > 0 {
-		rule.Buf = make([]byte, rule.BufLen)
-		if _, err := reader.Read(rule.Buf); err != nil {
-			return nil, errors.Wrap(err, "deserialization of buf failed")
-		}
+	var r auditRuleData
+	copy((*[ruleHeaderSize]byte)(unsafe.Pointer(&r))[:], data)
+	if uint32(len(data[ruleHeaderSize:])) < r.BufLen {
+		return nil, io.ErrUnexpectedEOF
 	}
-
-	return rule, nil
+	data = data[ruleHeaderSize:]
+	r.Buf = append(r.Buf, data[:r.BufLen]...)
+	return &r, nil
 }

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -390,11 +390,11 @@ type ruleData struct {
 }
 
 func (d ruleData) toAuditRuleData() (*auditRuleData, error) {
-	rule := &auditRuleData{
+	rule := &auditRuleData{auditRuleHeader: auditRuleHeader{
 		Flags:      d.flags,
 		Action:     d.action,
 		FieldCount: uint32(len(d.fields)),
-	}
+	}}
 
 	if d.allSyscalls {
 		for i := 0; i < len(rule.Mask)-1; i++ {
@@ -725,7 +725,7 @@ func addFilter(rule *ruleData, lhs, comparator, rhs string) error {
 			return err
 		}
 		rule.values = append(rule.values, arg)
-	//case SessionIDField:
+	// case SessionIDField:
 	case inodeField:
 		// Flag must be FilterExit.
 		if rule.flags != exitFilter {
@@ -832,7 +832,7 @@ func getExitCode(exit string) (int32, error) {
 }
 
 func getArch(arch string) (string, uint32, error) {
-	var realArch = arch
+	realArch := arch
 	switch strings.ToLower(arch) {
 	case "b64":
 		runtimeArch, err := getRuntimeArch()

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -135,6 +135,7 @@ func ToCommandLine(wf WireFormat, resolveIds bool) (rule string, err error) {
 	if permIdx, ok := existingFields[permField]; r.allSyscalls && ok {
 		extraFields, pos := false, 0
 		var path, key string
+	loop:
 		for _, fieldId := range r.fields {
 			switch fieldId {
 			case keyField, pathField, dirField:
@@ -150,7 +151,7 @@ func ToCommandLine(wf WireFormat, resolveIds bool) (rule string, err error) {
 			case permField:
 			default:
 				extraFields = true
-				break
+				break loop
 			}
 		}
 		if !extraFields {
@@ -435,7 +436,7 @@ func (rule *ruleData) fromAuditRuleData(in *auditRuleData) error {
 	for i := 0; rule.allSyscalls && i < len(in.Mask)-1; i++ {
 		rule.allSyscalls = in.Mask[i] == 0xFFFFFFFF
 	}
-	if rule.allSyscalls == false {
+	if !rule.allSyscalls {
 		for word, bits := range in.Mask {
 			for bit := uint32(0); bit < 32; bit++ {
 				if bits&(1<<bit) != 0 {

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -53,6 +53,12 @@ func TestBuild(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, wireFormat)
+
+	// Confirm round-trip.
+	arData, err := fromWireFormat(wireFormat)
+	assert.NoError(t, err, "failed to unmarshal wire format")
+	got := arData.toWireFormat()
+	assert.Equal(t, wireFormat, got, "mismatch in round-trip data")
 }
 
 func TestAddFlag(t *testing.T) {


### PR DESCRIPTION
This reduces the load on encoding/binary.Read and others at the cost of using unsafe. Given that we are close to the border of the kernel here, this is pretty reasonable. Testing is increased to ensure that message serialisation is at least round-trippable.

Please take a look.