### PR TITLE
ci: run golangci-lint on new additions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,15 @@
+name: golangci-lint
+on:
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.2
+        with:
+          version: v1.44.0
+          only-new-issues: true
+          args: --timeout=5m


### PR DESCRIPTION
It turns out that partial tree and new issue analysis are not compatible yet.

Please take a look.