### PR TITLE
Add auparse and aucoalesce benchmark

### DIFF
--- a/aucoalesce/coalesce_test.go
+++ b/aucoalesce/coalesce_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/go-libaudit/v2/auparse"
@@ -211,4 +212,20 @@ func normalizeEvent(t testing.TB, event testEventOutput) map[string]interface{} 
 		t.Fatal(err)
 	}
 	return out
+}
+
+func BenchmarkCoalesceMessages(b *testing.B) {
+	files, err := filepath.Glob("testdata/*.yaml")
+	require.NoError(b, err)
+	var events []testEvent
+	for _, f := range files {
+		events = append(events, readEventsFromYAML(b, f)...)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := CoalesceMessages(events[i%len(events)].messages); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/auparse/auparse_test.go
+++ b/auparse/auparse_test.go
@@ -27,10 +27,12 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
@@ -310,6 +312,30 @@ func BenchmarkParseAuditHeaderRegex(b *testing.B) {
 		msec, _ := strconv.ParseInt(matches[2], 10, 64)
 		_ = time.Unix(sec, msec*int64(time.Millisecond))
 		_, _ = strconv.Atoi(matches[3])
+	}
+}
+
+func BenchmarkParseLogLine(b *testing.B) {
+	// Build corpus of valid messages from the test data.
+	files, err := filepath.Glob("testdata/*.log")
+	require.NoError(b, err)
+	var msgs []string
+	for _, f := range files {
+		data, err := ioutil.ReadFile(f)
+		require.NoError(b, err)
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if _, err = ParseLogLine(line); err == nil {
+				msgs = append(msgs, line)
+			}
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msg := msgs[i%len(msgs)]
+		if _, err = ParseLogLine(msg); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Add benchmarks based on logs from testdata/.

```
goos: darwin
goarch: amd64
pkg: github.com/elastic/go-libaudit/v2/aucoalesce
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkCoalesceMessages-12             1655539              3612 ns/op            2718 B/op         13 allocs/op
PASS
ok      github.com/elastic/go-libaudit/v2/aucoalesce    9.707s
```
```
goos: darwin
goarch: amd64
pkg: github.com/elastic/go-libaudit/v2/auparse
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkParseAuditHeader-12            50767164               115.8 ns/op            21 B/op          3 allocs/op
BenchmarkParseAuditHeaderRegex-12       11188456               539.0 ns/op           128 B/op          2 allocs/op
BenchmarkParseLogLine-12                18334200               330.6 ns/op           374 B/op          4 allocs/op
```