### PR TITLE
allow short buffers to be unmarshaled

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-GO111MODULE=off go get -u github.com/elastic/go-licenser
+go install github.com/elastic/go-licenser@latest
 go get -d -t ./...
 go mod download
 go mod verify
@@ -24,7 +24,7 @@ fi
 # Run the tests
 set +e
 mkdir -p build
-go get -v -u github.com/jstemmer/go-junit-report
+go install github.com/jstemmer/go-junit-report@latest
 export OUT_FILE="build/test-report.out"
 go test -v $(go list ./... | grep -v /vendor/) | tee ${OUT_FILE}
 status=$?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Fix change in behaviour that causes error when unmarshaling `AuditStatus` with a short buffer. [#110](https://github.com/elastic/go-libaudit/pull/110)
+
 ### Removed
 
 ### Deprecated

--- a/audit.go
+++ b/audit.go
@@ -615,7 +615,7 @@ func (s AuditStatus) toWireFormat() []byte {
 // struct.
 func (s *AuditStatus) FromWireFormat(buf []byte) error {
 	if len(buf) < sizeofAuditStatus {
-		return io.ErrUnexpectedEOF
+		*s = AuditStatus{}
 	}
 	copy((*[unsafe.Sizeof(AuditStatus{})]byte)(unsafe.Pointer(s))[:], buf)
 	return nil


### PR DESCRIPTION
This makes the behaviour match the documentation, and is required for fixing https://github.com/elastic/beats/issues/31616.