### PR TITLE
Reduce heap allocations in `auparse.go`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Fix change in behaviour that causes error when unmarshaling `AuditStatus` with a short buffer. [#110](https://github.com/elastic/go-libaudit/pull/110)
+- Reduce heap allocations when parsing and enriching auditd events. [#111](https://github.com/elastic/go-libaudit/pull/111)
 
 ### Removed
 

--- a/auparse/auparse.go
+++ b/auparse/auparse.go
@@ -311,6 +311,29 @@ func extractKeyValuePairs(msg string, data map[string]*field) {
 	}
 }
 
+func extractKeyValuePairsNew(msg string) map[string]field {
+	data := make(map[string]field, 0)
+	matches := kvRegex.FindAllStringSubmatch(msg, -1)
+	for _, m := range matches {
+		key := m[1]
+		f := *newField(m[2])
+		f.Set(trimQuotesAndSpace(m[2]))
+
+		// Drop fields with useless values.
+		switch f.Value() {
+		case "", "?", "?,", "(null)":
+			continue
+		}
+
+		if key == "msg" {
+			data = extractKeyValuePairsNew(f.Value())
+		} else {
+			data[key] = f
+		}
+	}
+	return data
+}
+
 func trimQuotesAndSpace(v string) string { return strings.Trim(v, `'" `) }
 
 // Enrichment after KV parsing

--- a/auparse/auparse_test.go
+++ b/auparse/auparse_test.go
@@ -209,15 +209,9 @@ func BenchmarkExtractKeyValuePairs(b *testing.B) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-		b.Run(tc.name+"_current", func(b *testing.B) {
+		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				b.StartTimer()
-				out := extractKeyValuePairs(tc.in)
-				b.StopTimer()
-				if !assert.Equal(b, tc.out, out, "failed on: %v", tc.in) {
-					b.FailNow()
-				}
+				extractKeyValuePairs(tc.in)
 			}
 		})
 	}
@@ -278,9 +272,7 @@ var dataTests = []struct {
 }
 
 func TestExtractAndEnrichData(t *testing.T) {
-	tests := dataTests
-	for _, tc := range tests {
-		tc := tc
+	for _, tc := range dataTests {
 		t.Run(tc.name, func(t *testing.T) {
 			msg, err := ParseLogLine(tc.text)
 			if err != nil {
@@ -294,22 +286,16 @@ func TestExtractAndEnrichData(t *testing.T) {
 }
 
 func BenchmarkAuditMessageData(b *testing.B) {
-	tests := dataTests
-	for _, tc := range tests {
-		tc := tc
+	for _, tc := range dataTests {
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				var (
-					data map[string]string
-					err  error
-				)
 				msg, errP := ParseLogLine(tc.text)
 				if errP != nil {
 					b.Fatalf("parsing message: %v", errP)
 				}
 				b.StartTimer()
-				data, err = msg.Data()
+				data, err := msg.Data()
 				b.StopTimer()
 				require.Nil(b, err)
 				assert.Equal(b, tc.output, data)
@@ -414,6 +400,9 @@ func loadAuditMessages(tb testing.TB, name string) []*AuditMessage {
 		}
 
 		messages = append(messages, msg)
+	}
+	if err := s.Err(); err != nil {
+		tb.Fatalf("incomplete file loading: %v", err)
 	}
 	return messages
 }


### PR DESCRIPTION
## Reason for this PR
We noticed high GC pressure (recorded by profiling) when running `auditbeat` and an eBPF-powered profiling agent.
When auditbeat is configured to read _all_ BPF syscalls, and a profiling agent based on eBPF executes many, a relevant CPU consumption goes into parsing and sending the increased number of events from auditd.

## Details
With this PR we have a reduction of ~15% of heap allocations in the parse/enrich phases of `AuditMessage`.
The commits contain some additional benchmarks and experiments that lead to the improvement.

The benchmark output
```
# before
BenchmarkExtractKeyValuePairs/bpf_message_current-8         	  113053	      9687 ns/op	    2198 B/op	      33 allocs/op
BenchmarkExtractKeyValuePairs/short_message_current-8       	  292078	      3440 ns/op	    1232 B/op	       9 allocs/op

# after
BenchmarkExtractKeyValuePairs/bpf_message_current-8         	  118813	      8945 ns/op	    2616 B/op	      24 allocs/op
BenchmarkExtractKeyValuePairs/short_message_current-8       	  586594	      3114 ns/op	     913 B/op	       7 allocs/op
```

This is not a definitive solution to CPU usage increase, but it's a step further 😄 