### PR TITLE
allow shorter buffers to be unmarshaled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix change in behaviour that causes error when unmarshaling `AuditStatus` with a short buffer. [#110](https://github.com/elastic/go-libaudit/pull/110)
 - Reduce heap allocations when parsing and enriching auditd events. [#111](https://github.com/elastic/go-libaudit/pull/111)
+- Relax short buffer requirement further to allow for kernels that do not support the backlog wait feature. [#113](https://github.com/elastic/go-libaudit/pull/113)
 
 ### Removed
 

--- a/audit.go
+++ b/audit.go
@@ -608,8 +608,10 @@ const (
 
 	// MinSizeofAuditStatus is the minimum usable message size that
 	// is acceptable for unmarshaling from the wire format. Messages
-	// this size do not report backlog_wait_time_actual.
-	MinSizeofAuditStatus = sizeofAuditStatus - int(unsafe.Sizeof(uint32(0)))
+	// this size do not report features after the FeatureBitmap field.
+	// Users should consult the feature bitmap to determine which
+	// features are valid.
+	MinSizeofAuditStatus = int(unsafe.Offsetof(AuditStatus{}.FeatureBitmap) + unsafe.Sizeof(AuditStatus{}.FeatureBitmap))
 )
 
 func (s AuditStatus) toWireFormat() []byte {


### PR DESCRIPTION
The previous fix assumed that backlog_wait_time was present in all
kernels in the support matrix. This is not the case, so only require
fields up to the feature bitmap.