### PR TITLE
use allocation free converstion from byte slice to string

### DIFF
--- a/auparse/auparse_test.go
+++ b/auparse/auparse_test.go
@@ -95,7 +95,7 @@ func TestNormalizeAuditMessage(t *testing.T) {
 }
 
 func TestParseAuditHeader(t *testing.T) {
-	ts, seq, end, err := parseAuditHeader([]byte(syscallMsg))
+	ts, seq, end, err := parseAuditHeader(syscallMsg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -450,9 +450,8 @@ func readGoldenFile(name string) ([]*StoredAuditMessage, error) {
 }
 
 func BenchmarkParseAuditHeader(b *testing.B) {
-	msg := []byte(syscallMsg)
 	for i := 0; i < b.N; i++ {
-		_, _, _, err := parseAuditHeader(msg)
+		_, _, _, err := parseAuditHeader(syscallMsg)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/auparse/hex.go
+++ b/auparse/hex.go
@@ -25,6 +25,8 @@ import (
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/elastic/go-libaudit/v2/internal"
 )
 
 const nullTerminator = "\x00"
@@ -40,7 +42,7 @@ func hexToString(h string) (string, error) {
 		output = output[:nullTerm]
 	}
 
-	return string(output), nil
+	return internal.UnsafeByteSlice2String(output), nil
 }
 
 func hexToStrings(h string) ([]string, error) {

--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -144,6 +144,6 @@ func receive(r *libaudit.AuditClient) error {
 			continue
 		}
 
-		fmt.Printf("type=%v msg=%v\n", rawEvent.Type, string(rawEvent.Data))
+		fmt.Printf("type=%v msg=%s\n", rawEvent.Type, rawEvent.Data)
 	}
 }

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import "unsafe"
+
+// UnsafeByteSlice2String converts a byte slice into a string without a heap allocation.
+// Be aware that the byte slice and the string share the same memory - which makes
+// the string mutable.
+func UnsafeByteSlice2String(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/internal/helper_test.go
+++ b/internal/helper_test.go
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"testing"
+)
+
+func TestUnsafeByteSlice2String(t *testing.T) {
+	tests := [][]byte{
+		[]byte("hello world"),
+		[]byte(`{"some":"json", "simple": true}`),
+		[]byte(`multi
+		line
+		test`),
+	}
+
+	for _, test := range tests {
+		t.Run(string(test), func(t *testing.T) {
+			str := UnsafeByteSlice2String(test)
+			if str != string(test) {
+				t.Fatalf("Expected '%s' but got '%s'", string(test), str)
+			}
+		})
+	}
+}

--- a/reassembler.go
+++ b/reassembler.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/elastic/go-libaudit/v2/auparse"
+	"github.com/elastic/go-libaudit/v2/internal"
 )
 
 var errReassemblerClosed = errors.New("reassembler closed")
@@ -98,7 +99,7 @@ func (r *Reassembler) PushMessage(msg *auparse.AuditMessage) {
 // timestamp and sequence number. If parsing fails then an error will be
 // returned. See PushMessage.
 func (r *Reassembler) Push(typ auparse.AuditMessageType, rawData []byte) error {
-	msg, err := auparse.Parse(typ, string(rawData))
+	msg, err := auparse.Parse(typ, internal.UnsafeByteSlice2String(rawData))
 	if err != nil {
 		return err
 	}

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	"github.com/elastic/go-libaudit/v2/auparse"
-	"github.com/elastic/go-libaudit/v2/internal"
 )
 
 //go:generate sh -c "go tool cgo -godefs defs_kernel_types.go > zkernel_types.go && gofmt -w zkernel_types.go"
@@ -466,7 +465,7 @@ func (r *ruleData) fromAuditRuleData(in *auditRuleData) error {
 			if end > in.BufLen {
 				return fmt.Errorf("field %d overflows buffer", i)
 			}
-			r.strings = append(r.strings, internal.UnsafeByteSlice2String(in.Buf[offset:end]))
+			r.strings = append(r.strings, string(in.Buf[offset:end]))
 			offset = end
 		}
 	}
@@ -991,7 +990,7 @@ func (bits permission) String() string {
 	if bits&attrPerm != 0 {
 		perms = append(perms, 'a')
 	}
-	return internal.UnsafeByteSlice2String(perms)
+	return string(perms)
 }
 
 func getFiletype(filetype string) (filetype, error) {

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/elastic/go-libaudit/v2/auparse"
+	"github.com/elastic/go-libaudit/v2/internal"
 )
 
 //go:generate sh -c "go tool cgo -godefs defs_kernel_types.go > zkernel_types.go && gofmt -w zkernel_types.go"
@@ -465,7 +466,7 @@ func (r *ruleData) fromAuditRuleData(in *auditRuleData) error {
 			if end > in.BufLen {
 				return fmt.Errorf("field %d overflows buffer", i)
 			}
-			r.strings = append(r.strings, string(in.Buf[offset:end]))
+			r.strings = append(r.strings, internal.UnsafeByteSlice2String(in.Buf[offset:end]))
 			offset = end
 		}
 	}
@@ -990,7 +991,7 @@ func (bits permission) String() string {
 	if bits&attrPerm != 0 {
 		perms = append(perms, 'a')
 	}
-	return string(perms)
+	return internal.UnsafeByteSlice2String(perms)
 }
 
 func getFiletype(filetype string) (filetype, error) {


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

Reduce the number of allocations for converting a slice of bytes to a string.
Less allocation results in less work for GC.