### PR TITLE
reorder structs for better memory usage

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -404,8 +404,8 @@ func (c *AuditClient) SetBacklogWaitTime(waitTime int32, wm WaitMode) error {
 
 // RawAuditMessage is a raw audit message received from the kernel.
 type RawAuditMessage struct {
-	Type auparse.AuditMessageType
 	Data []byte // RawData is backed by the read buffer so make a copy.
+	Type auparse.AuditMessageType
 }
 
 // Receive reads an audit message from the netlink socket. If you are going to

--- a/auparse/auparse.go
+++ b/auparse/auparse.go
@@ -51,15 +51,14 @@ var (
 
 // AuditMessage represents a single audit message.
 type AuditMessage struct {
-	RecordType AuditMessageType // Record type from netlink header.
-	Timestamp  time.Time        // Timestamp parsed from payload in netlink message.
-	Sequence   uint32           // Sequence parsed from payload.
-	RawData    string           // Raw message as a string.
-
-	offset int               // offset is the index into RawData where the header ends and message begins.
-	data   map[string]string // The key value pairs parsed from the message.
-	tags   []string          // The keys associated with the event (e.g. the values set in rules with -F key=exec).
-	error  error             // Error that occurred while parsing.
+	Timestamp  time.Time         // Timestamp parsed from payload in netlink message.
+	error      error             // Error that occurred while parsing.
+	data       map[string]string // The key value pairs parsed from the message.
+	RawData    string            // Raw message as a string.
+	tags       []string          // The keys associated with the event (e.g. the values set in rules with -F key=exec).
+	offset     int               // offset is the index into RawData where the header ends and message begins.
+	Sequence   uint32            // Sequence parsed from payload.
+	RecordType AuditMessageType  // Record type from netlink header.
 }
 
 type field struct {

--- a/netlink.go
+++ b/netlink.go
@@ -59,13 +59,13 @@ type NetlinkParser func([]byte) ([]syscall.NetlinkMessage, error)
 
 // NetlinkClient is a generic client for sending and receiving netlink messages.
 type NetlinkClient struct {
-	fd         int              // File descriptor used for communication.
+	respWriter io.Writer
 	src        syscall.Sockaddr // Local socket address.
 	dest       syscall.Sockaddr // Remote socket address (client assumes the dest is the kernel).
-	pid        uint32           // Port ID of the local socket.
-	seq        uint32           // Sequence number used in outgoing messages.
 	readBuf    []byte
-	respWriter io.Writer
+	fd         int    // File descriptor used for communication.
+	pid        uint32 // Port ID of the local socket.
+	seq        uint32 // Sequence number used in outgoing messages.
 }
 
 // NewNetlinkClient creates a new NetlinkClient. It creates a socket and binds

--- a/rule/flags/flags.go
+++ b/rule/flags/flags.go
@@ -85,9 +85,7 @@ func Parse(args string) (rule.Rule, error) {
 
 // ruleFlagSet is a used to parse the flags used in an audit rule.
 type ruleFlagSet struct {
-	Type rule.Type
-
-	DeleteAll bool // [-D] Delete all rules.
+	flagSet *flag.FlagSet
 
 	// Audit Rule
 	Prepend  addFlag    // -A Prepend rule (list,action) or (action,list).
@@ -101,7 +99,9 @@ type ruleFlagSet struct {
 
 	Key stringList // -k Key(s) to associate with the rule.
 
-	flagSet *flag.FlagSet
+	Type rule.Type
+
+	DeleteAll bool // [-D] Delete all rules.
 }
 
 func newRuleFlagSet() *ruleFlagSet {

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -373,19 +373,15 @@ func addKeys(data *ruleData, keys []string) error {
 }
 
 type ruleData struct {
-	flags  filter
-	action action
-
-	allSyscalls bool
+	arch        string
+	fieldFlags  []operator
+	strings     []string
 	syscalls    []uint32
-
-	fields     []field
-	values     []uint32
-	fieldFlags []operator
-
-	strings []string
-
-	arch string
+	fields      []field
+	values      []uint32
+	flags       filter
+	action      action
+	allSyscalls bool
 }
 
 func (r ruleData) toAuditRuleData() (*auditRuleData, error) {

--- a/rule/types.go
+++ b/rule/types.go
@@ -37,8 +37,8 @@ type Rule interface {
 
 // DeleteAllRule deletes all existing rules.
 type DeleteAllRule struct {
-	Type Type
 	Keys []string // Delete rules that have these keys.
+	Type Type
 }
 
 // TypeOf returns DeleteAllRuleType.
@@ -47,10 +47,10 @@ func (r *DeleteAllRule) TypeOf() Type { return r.Type }
 // FileWatchRule is used to audit access to particular files or directories
 // that you may be interested in.
 type FileWatchRule struct {
-	Type        Type
 	Path        string
 	Permissions []AccessType
 	Keys        []string
+	Type        Type
 }
 
 // TypeOf returns FileWatchRuleType.
@@ -58,12 +58,12 @@ func (r *FileWatchRule) TypeOf() Type { return r.Type }
 
 // SyscallRule is used to audit invocations of specific syscalls.
 type SyscallRule struct {
-	Type     Type
 	List     string
 	Action   string
 	Filters  []FilterSpec
 	Syscalls []string
 	Keys     []string
+	Type     Type
 }
 
 // TypeOf returns either AppendSyscallRuleType or PrependSyscallRuleType.
@@ -106,10 +106,10 @@ const (
 
 // FilterSpec defines a filter to apply to a syscall rule.
 type FilterSpec struct {
-	Type       FilterType
 	LHS        string
 	Comparator string
 	RHS        string
+	Type       FilterType
 }
 
 func (f *FilterSpec) String() string {


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

Reorder structs to reduce required memory.