### PR TITLE
Check fieldalignment in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,10 @@ linters-settings:
     checks:
       - all
       - -ST1001 # ST1001 - Dot imports are discouraged
+  govet:
+    # Enable analyzers in addition to defaults.
+    enable:
+      - fieldalignment
 
 issues:
   include:
@@ -111,3 +115,6 @@ issues:
       linters:
         - errcheck
       text: 'out[\w.]+Write'
+    # Ignore struct alignment in tests.
+    - path: '(.+)_test\.go'
+      text: 'fieldalignment'

--- a/rule/binary.go
+++ b/rule/binary.go
@@ -35,6 +35,7 @@ type WireFormat []byte
 // fields.  It corresponds with AUDIT_ADD_RULE, AUDIT_DEL_RULE and
 // AUDIT_LIST_RULES requests.
 // https://github.com/linux-audit/audit-kernel/blob/v3.15/include/uapi/linux/audit.h#L423-L437
+//nolint:govet // This struct needs to match the kernel struct so cannot be aligned.
 type auditRuleData struct {
 	auditRuleHeader
 	Buf []byte // String fields.


### PR DESCRIPTION
In #117 some alignment issues were fixed. This will help prevent future regressions.