### PR TITLE
Fix support of kernel < 3.0

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -611,7 +611,7 @@ const (
 	// this size do not report features after the FeatureBitmap field.
 	// Users should consult the feature bitmap to determine which
 	// features are valid.
-	MinSizeofAuditStatus = int(unsafe.Offsetof(AuditStatus{}.FeatureBitmap) + unsafe.Sizeof(AuditStatus{}.FeatureBitmap))
+	MinSizeofAuditStatus = int(unsafe.Offsetof(AuditStatus{}.FeatureBitmap))
 )
 
 func (s AuditStatus) toWireFormat() []byte {


### PR DESCRIPTION
Changed min auditStatus size to 32 bite as old kernel do have only the following fields:
```
enabled 1
failure 1
pid 66
rate_limit 0
backlog_limit 320
lost 0
backlog 0
```