### PR TITLE
Revert change to Reassembler.Push from #116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Reduce allocations when converting bytes to strings for received messages. [#116](https://github.com/elastic/go-libaudit/pull/116) [#120](https://github.com/elastic/go-libaudit/pull/120)
+- Reduce allocations when converting bytes to strings for received messages. [#116](https://github.com/elastic/go-libaudit/pull/116) [#120](https://github.com/elastic/go-libaudit/pull/122)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Reduce allocations when converting bytes to strings for received messages. [#116](https://github.com/elastic/go-libaudit/pull/116)
+- Reduce allocations when converting bytes to strings for received messages. [#116](https://github.com/elastic/go-libaudit/pull/116) [#120](https://github.com/elastic/go-libaudit/pull/120)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Reduce allocations when converting bytes to strings for received messages. [#116](https://github.com/elastic/go-libaudit/pull/116) [#120](https://github.com/elastic/go-libaudit/pull/122)
+- Reduce allocations when converting bytes to strings for received messages. [#116](https://github.com/elastic/go-libaudit/pull/116) [#122](https://github.com/elastic/go-libaudit/pull/122)
 
 ### Removed
 

--- a/reassembler.go
+++ b/reassembler.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/elastic/go-libaudit/v2/auparse"
-	"github.com/elastic/go-libaudit/v2/internal"
 )
 
 var errReassemblerClosed = errors.New("reassembler closed")
@@ -94,12 +93,12 @@ func (r *Reassembler) PushMessage(msg *auparse.AuditMessage) {
 	r.callback(evicted, lost)
 }
 
-// Push pushes a new audit message into the Reassembler. This is a convenence
+// Push pushes a new audit message into the Reassembler. This is a convenience
 // function that handles calling auparse.Parse() to extract the message's
-// timestamp and sequence number. If parsing fails then an error will be
-// returned. See PushMessage.
+// timestamp and sequence number. It copies the rawData contents. If parsing
+// fails then an error will be returned. See PushMessage.
 func (r *Reassembler) Push(typ auparse.AuditMessageType, rawData []byte) error {
-	msg, err := auparse.Parse(typ, internal.UnsafeByteSlice2String(rawData))
+	msg, err := auparse.Parse(typ, string(rawData))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`Reassembler.Push` has always made a copy of the provided byte slice.

In #116 it was modified to not copy the slice. But this was a breaking change
to its behavior and causes bugs for existing users. The typical use of this
function is to parse data from [`AuditClient.Receive`](https://pkg.go.dev/github.com/elastic/go-libaudit/v2#AuditClient.Receive) which explicitly documents
that caller must make a copy of the data if they are going to retain it beyond
the next `Receive` call.

Relates #116