### PR TITLE
ci: add micro-benchmark

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         unstash 'source'
         withGoEnv(){
           dir("${BASE_DIR}"){
-            sh(label: 'test', script: '.ci/test.sh')
+            sh(label: 'bench', script: '.ci/bench.sh')
             generateGoBenchmarkDiff(file: 'bench.out', filter: 'exclude')
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
         withGoEnv(){
           dir("${BASE_DIR}"){
             sh(label: 'bench', script: '.ci/bench.sh')
+            sendBenchmarks(file: 'bench.out', index: 'benchmark-go-libaudit')
             generateGoBenchmarkDiff(file: 'bench.out', filter: 'exclude')
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
         withGoEnv(){
           dir("${BASE_DIR}"){
             sh(label: 'bench', script: '.ci/bench.sh')
-            sendBenchmarks(file: 'bench.out', index: 'benchmark-go-libaudit')
+            sendBenchmarks(file: 'bench.out', index: 'benchmark-go-libaudit', useGoBench: true)
             generateGoBenchmarkDiff(file: 'bench.out', filter: 'exclude')
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -48,6 +48,19 @@ pipeline {
         }
       }
     }
+    stage('Microbench') {
+      options { skipDefaultCheckout() }
+      steps {
+        deleteDir()
+        unstash 'source'
+        withGoEnv(){
+          dir("${BASE_DIR}"){
+            sh(label: 'test', script: '.ci/test.sh')
+            generateGoBenchmarkDiff(file: 'bench.out', filter: 'exclude')
+          }
+        }
+      }
+    }
   }
   post {
     cleanup {

--- a/.ci/bench.sh
+++ b/.ci/bench.sh
@@ -4,4 +4,4 @@ set -euxo pipefail
 go get -d -t ./...
 go mod download
 
-go test -count=5 -benchmem -run=XXX -benchtime=100ms -bench='.*' -v $(go list ./... | grep -v /vendor/)
+go test -count=5 -benchmem -run=XXX -benchtime=100ms -bench='.*' -v $(go list ./... | grep -v /vendor/) | tee bench.out

--- a/.ci/bench.sh
+++ b/.ci/bench.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+go get -d -t ./...
+go mod download
+
+go test -count=5 -benchmem -run=XXX -benchtime=100ms -bench='.*' -v $(go list ./... | grep -v /vendor/)


### PR DESCRIPTION
As I've seen a comment in https://github.com/elastic/go-libaudit/pull/116#pullrequestreview-1033183823 regarding the bench

I'd like to propose this change in addition to another one (later on), since the `bench.out` file will be stored to be consumed to compare the result between PRs and their target branches.

Siimilar to https://github.com/elastic/apm-server/pull/8471#issuecomment-1165633680