### PR TITLE
ci: enable report benchmark diff on a PR basis

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(prComment: true)
+      notifyBuildResult(prComment: true, goBenchmarkComment: true)
     }
   }
 }


### PR DESCRIPTION
Notify go benchmark report on a GitHub comment


similar to https://github.com/elastic/apm-server/pull/8471


See https://github.com/elastic/go-libaudit/pull/124#issuecomment-1232968403

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/2871786/187695929-e3da44ae-cc2a-42fa-87dd-5c5a40052580.png">
