### PR TITLE
Mask file mode with 0o7777 instead of 0o777

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Expanded the bitmask applied to ECS `file.mode` in the aucoalesce package so that the SUID, SGID, and sticky bits can be represented. [#137](https://github.com/elastic/go-libaudit/issues/137)
+
 ### Removed
 
 ### Deprecated

--- a/aucoalesce/coalesce.go
+++ b/aucoalesce/coalesce.go
@@ -723,7 +723,7 @@ func setFileObject(event *Event, pathIndexHint int) error {
 		}
 
 		m := os.FileMode(mode)
-		event.File.Mode = fmt.Sprintf("%#04o", m.Perm())
+		event.File.Mode = fmt.Sprintf("%04o", 0o7777&m)
 
 		switch {
 		case m.IsRegular():

--- a/aucoalesce/testdata/ubuntu-20.04.6-linux-5.15.0-1034-gcp.json.golden
+++ b/aucoalesce/testdata/ubuntu-20.04.6-linux-5.15.0-1034-gcp.json.golden
@@ -1,0 +1,124 @@
+[
+  {
+    "test_name": "file_mode_preservation",
+    "event": {
+      "@timestamp": "2023-06-13T14:29:11.525Z",
+      "sequence": 28860764,
+      "category": "audit-rule",
+      "record_type": "syscall",
+      "result": "success",
+      "session": "1456",
+      "tags": [
+        "susp_shell"
+      ],
+      "summary": {
+        "actor": {
+          "primary": "1005",
+          "secondary": "1005"
+        },
+        "action": "executed",
+        "object": {
+          "type": "file",
+          "primary": "/usr/bin/dash"
+        },
+        "how": "/usr/bin/dash"
+      },
+      "user": {
+        "ids": {
+          "auid": "1005",
+          "egid": "0",
+          "euid": "0",
+          "fsgid": "0",
+          "fsuid": "0",
+          "gid": "1006",
+          "sgid": "0",
+          "suid": "0",
+          "uid": "1005"
+        },
+        "selinux": {
+          "user": "unconfined"
+        }
+      },
+      "process": {
+        "pid": "2380168",
+        "ppid": "2380071",
+        "title": "dash -p",
+        "name": "dash",
+        "exe": "/usr/bin/dash",
+        "args": [
+          "dash",
+          "-p"
+        ]
+      },
+      "file": {
+        "path": "/usr/bin/dash",
+        "device": "00:00",
+        "inode": "1593",
+        "mode": "6755",
+        "uid": "0",
+        "gid": "0"
+      },
+      "data": {
+        "a0": "55d85d6719d0",
+        "a1": "55d85d69c970",
+        "a2": "55d85d720450",
+        "a3": "8",
+        "arch": "x86_64",
+        "argc": "2",
+        "exit": "0",
+        "syscall": "execve",
+        "tty": "pts0"
+      },
+      "paths": [
+        {
+          "cap_fe": "0",
+          "cap_fi": "0",
+          "cap_fp": "0",
+          "cap_frootid": "0",
+          "cap_fver": "0",
+          "dev": "08:01",
+          "inode": "1593",
+          "item": "0",
+          "mode": "0106755",
+          "name": "/usr/bin/dash",
+          "nametype": "NORMAL",
+          "ogid": "0",
+          "ouid": "0",
+          "rdev": "00:00"
+        },
+        {
+          "cap_fe": "0",
+          "cap_fi": "0",
+          "cap_fp": "0",
+          "cap_frootid": "0",
+          "cap_fver": "0",
+          "dev": "08:01",
+          "inode": "4382",
+          "item": "1",
+          "mode": "0100755",
+          "name": "/lib64/ld-linux-x86-64.so.2",
+          "nametype": "NORMAL",
+          "ogid": "0",
+          "ouid": "0",
+          "rdev": "00:00"
+        }
+      ],
+      "ecs": {
+        "event": {
+          "category": [
+            "process"
+          ],
+          "type": [
+            "start"
+          ]
+        },
+        "user": {
+          "effective": {},
+          "target": {},
+          "changes": {}
+        },
+        "group": {}
+      }
+    }
+  }
+]

--- a/aucoalesce/testdata/ubuntu-20.04.6-linux-5.15.0-1034-gcp.yaml
+++ b/aucoalesce/testdata/ubuntu-20.04.6-linux-5.15.0-1034-gcp.yaml
@@ -1,0 +1,9 @@
+---
+tests:
+  # https://github.com/elastic/go-libaudit/issues/137
+  file_mode_preservation: |
+    type=SYSCALL msg=audit(1686666551.525:28860764): arch=c000003e syscall=59 success=yes exit=0 a0=55d85d6719d0 a1=55d85d69c970 a2=55d85d720450 a3=8 items=2 ppid=2380071 pid=2380168 auid=1005 uid=1005 gid=1006 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=1456 comm="dash" exe="/usr/bin/dash" subj=unconfined key="susp_shell"
+    type=EXECVE msg=audit(1686666551.525:28860764): argc=2 a0="dash" a1="-p"
+    type=PATH msg=audit(1686666551.525:28860764): item=0 name="/usr/bin/dash" inode=1593 dev=08:01 mode=0106755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+    type=PATH msg=audit(1686666551.525:28860764): item=1 name="/lib64/ld-linux-x86-64.so.2" inode=4382 dev=08:01 mode=0100755 ouid=0 ogid=0 rdev=00:00 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+    type=PROCTITLE msg=audit(1686666551.525:28860764): proctitle=64617368002D70


### PR DESCRIPTION
The file.mode field was only including the permission bits. This expands the mask to include the SUID, SGID, and sticky bits.

Fixes #137