### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Read .go-version file
         id: goversion
-        run: echo "::set-output name=version::$(cat .go-version)"
+        run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
## Proposed changes

Closes #139 

Update `.github/workflows/golangci-lint.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "::set-output name=version::$(cat .go-version)"
```

**TO-BE**

```yaml
run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
```
