### PR TITLE
Add normalization for exit_group syscall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add ECS normalization for `exit_group` syscall. [#149](https://github.com/elastic/go-libaudit/pull/149)
+
 ### Changed
 
 - Update syscall and architecture tables. [#147](https://github.com/elastic/go-libaudit/pull/147)

--- a/aucoalesce/normalizations.yaml
+++ b/aucoalesce/normalizations.yaml
@@ -548,6 +548,15 @@ normalizations:
     ecs:
       <<: *ecs-process
       type: change
+  - action: end
+    object:
+      what: process
+    how: syscall
+    syscalls:
+      # exit_group - exit all threads in a process
+      - exit_group
+    ecs: *ecs-process
+    type: end
 
   # Currently unhandled
   # this list comes from parsing linux man pages at https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git
@@ -673,7 +682,6 @@ normalizations:
   # acct - switch process accounting on or off
   # sigsuspend - wait for a signal
   # rt_sigsuspend - wait for a signal
-  # exit_group - exit all threads in a process
   # socket - create an endpoint for communication
   # ioctl_userfaultfd - create a file descriptor for handling page faults in user space
   # sched_get_priority_max - get static priority range


### PR DESCRIPTION
The exit_group syscall terminates all threads in a process, and is normally used to exit a process. This normalization adds 'end' action and type to the process ECS document.