### PR TITLE
Add opaque Payload property to AuditMessage

### DIFF
--- a/aucoalesce/coalesce_test.go
+++ b/aucoalesce/coalesce_test.go
@@ -21,7 +21,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -110,7 +109,7 @@ func testCoalesceEvent(t *testing.T, file string) {
 }
 
 func readEventsFromYAML(t testing.TB, name string) []testEvent {
-	file, err := ioutil.ReadFile(name)
+	file, err := os.ReadFile(name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +183,7 @@ func writeGoldenFile(name string, events []testEventOutput) error {
 func readGoldenFile(name string) ([]map[string]interface{}, error) {
 	name = strings.TrimSuffix(name, ".yaml")
 
-	data, err := ioutil.ReadFile(name + ".json.golden")
+	data, err := os.ReadFile(name + ".json.golden")
 	if err != nil {
 		return nil, err
 	}

--- a/aucoalesce/normalize_test.go
+++ b/aucoalesce/normalize_test.go
@@ -18,7 +18,7 @@
 package aucoalesce
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ func TestNormInit(t *testing.T) {
 }
 
 func TestLoadNormalizationConfig(t *testing.T) {
-	b, err := ioutil.ReadFile("normalizations.yaml")
+	b, err := os.ReadFile("normalizations.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/audit.go
+++ b/audit.go
@@ -30,8 +30,6 @@ import (
 	"time"
 	"unsafe"
 
-	"go.uber.org/multierr"
-
 	"github.com/elastic/go-libaudit/v2/auparse"
 )
 
@@ -441,7 +439,7 @@ func (c *AuditClient) Close() error {
 			err = c.set(status, NoWait)
 		}
 
-		err = multierr.Append(err, c.Netlink.Close())
+		err = errors.Join(err, c.Netlink.Close())
 	})
 
 	return err

--- a/auparse/auparse.go
+++ b/auparse/auparse.go
@@ -56,6 +56,8 @@ type AuditMessage struct {
 	Sequence   uint32           // Sequence parsed from payload.
 	RawData    string           // Raw message as a string.
 
+	Payload interface{} // Opaque payload. This can be anything that is needed to be preserved along with the message and returned back after aggregation.
+
 	offset int               // offset is the index into RawData where the header ends and message begins.
 	data   map[string]string // The key value pairs parsed from the message.
 	tags   []string          // The keys associated with the event (e.g. the values set in rules with -F key=exec).

--- a/auparse/auparse_test.go
+++ b/auparse/auparse_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -436,7 +435,7 @@ func writeGoldenFile(sourceName string, events []*AuditMessage) error {
 }
 
 func readGoldenFile(name string) ([]*StoredAuditMessage, error) {
-	data, err := ioutil.ReadFile(name)
+	data, err := os.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +479,7 @@ func BenchmarkParseLogLine(b *testing.B) {
 	require.NoError(b, err)
 	var msgs []string
 	for _, f := range files {
-		data, err := ioutil.ReadFile(f)
+		data, err := os.ReadFile(f)
 		require.NoError(b, err)
 		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
 			if _, err = ParseLogLine(line); err == nil {

--- a/auparse/mk_audit_exit_codes.go
+++ b/auparse/mk_audit_exit_codes.go
@@ -25,7 +25,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -144,7 +143,7 @@ func readErrorNumbers() ([]ErrorNumber, error) {
 }
 
 func run() error {
-	tmp, err := ioutil.TempDir("", "mk_audit_exit_codes")
+	tmp, err := os.MkdirTemp("", "mk_audit_exit_codes")
 	if err != nil {
 		return err
 	}
@@ -202,7 +201,7 @@ func run() error {
 		}
 	}
 
-	if err = ioutil.WriteFile(flagOut, buf.Bytes(), 0o644); err != nil {
+	if err = os.WriteFile(flagOut, buf.Bytes(), 0o644); err != nil {
 		return err
 	}
 

--- a/auparse/mk_audit_msg_types.go
+++ b/auparse/mk_audit_msg_types.go
@@ -26,7 +26,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -246,7 +245,7 @@ func readRecordTypes() (map[string]int, error) {
 }
 
 func run() error {
-	tmp, err := ioutil.TempDir("", "mk_audit_msg_types")
+	tmp, err := os.MkdirTemp("", "mk_audit_msg_types")
 	if err != nil {
 		return err
 	}

--- a/auparse/testdata/test3.log.golden
+++ b/auparse/testdata/test3.log.golden
@@ -373,7 +373,7 @@
       "ip": "0xb7670aac",
       "pid": "11217",
       "ses": "21",
-      "sig": "SIGSYS",
+      "sig": "SIGUSR2",
       "syscall": "getpgid",
       "uid": "22"
     }

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,17 @@
 module github.com/elastic/go-libaudit/v2
 
-go 1.16
+go 1.21
 
 require (
 	github.com/elastic/go-licenser v0.4.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0
-	go.uber.org/multierr v1.7.0
 	golang.org/x/sys v0.11.0
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,14 +8,9 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:C
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
-go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=

--- a/rule/flags/flags.go
+++ b/rule/flags/flags.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"strings"
 
@@ -115,7 +115,7 @@ func newRuleFlagSet() *ruleFlagSet {
 	rule := &ruleFlagSet{
 		flagSet: flag.NewFlagSet("rule", flag.ContinueOnError),
 	}
-	rule.flagSet.SetOutput(ioutil.Discard)
+	rule.flagSet.SetOutput(io.Discard)
 
 	rule.flagSet.BoolVar(&rule.DeleteAll, "D", false, "delete all")
 	rule.flagSet.Var(&rule.Append, "a", "append rule")
@@ -134,7 +134,7 @@ func (r *ruleFlagSet) Usage() string {
 	buf := new(bytes.Buffer)
 	r.flagSet.SetOutput(buf)
 	r.flagSet.Usage()
-	r.flagSet.SetOutput(ioutil.Discard)
+	r.flagSet.SetOutput(io.Discard)
 	return buf.String()
 }
 

--- a/rule/gen_testdata_test.go
+++ b/rule/gen_testdata_test.go
@@ -26,7 +26,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"flag"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -70,7 +69,7 @@ func TestUpdateGoldenData(t *testing.T) {
 }
 
 func makeGoldenFile(t testing.TB, rulesFile string) {
-	rules, err := ioutil.ReadFile(rulesFile)
+	rules, err := os.ReadFile(rulesFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +205,7 @@ func makePaths(t testing.TB, tmpDir, rule string) []string {
 			if err := os.MkdirAll(dir, 0o700); err != nil {
 				t.Fatal(err)
 			}
-			if err := ioutil.WriteFile(testPath, nil, 0o600); err != nil {
+			if err := os.WriteFile(testPath, nil, 0o600); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/rule/rule_integ_test.go
+++ b/rule/rule_integ_test.go
@@ -23,7 +23,6 @@ package rule_test
 import (
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +66,7 @@ func TestBuildGolden(t *testing.T) {
 
 func testRulesFromGoldenFile(t *testing.T, goldenFile string) {
 	t.Run(filepath.Base(goldenFile), func(t *testing.T) {
-		testdata, err := ioutil.ReadFile(goldenFile)
+		testdata, err := os.ReadFile(goldenFile)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -123,7 +122,7 @@ func mkdirTempPaths(t testing.TB, path string) {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(path, nil, 0o600); err != nil {
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
* Add opaque Payload property to AuditMessage
* Replace deprecated ioutil
* Get rid of go.uber.org/multierr dependency
* Update go to 1.21