### PR TITLE
Migrate from yaml.v2 to yaml.v3

### DIFF
--- a/aucoalesce/coalesce_test.go
+++ b/aucoalesce/coalesce_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/go-libaudit/v2/auparse"
 )
@@ -124,7 +124,7 @@ func readEventsFromYAML(t testing.TB, name string) []testEvent {
 		t.Fatal("failed to find 'tests' in yaml")
 	}
 
-	cases, ok := tests.(map[interface{}]interface{})
+	cases, ok := tests.(map[string]interface{})
 	if !ok {
 		t.Fatalf("unexpected type %T for 'tests'", tests)
 	}
@@ -146,7 +146,7 @@ func readEventsFromYAML(t testing.TB, name string) []testEvent {
 		}
 
 		testEvents = append(testEvents, testEvent{
-			name:     name.(string),
+			name:     name,
 			messages: msgs,
 		})
 	}

--- a/aucoalesce/normalizations.yaml
+++ b/aucoalesce/normalizations.yaml
@@ -2,12 +2,6 @@
 # Macros declares some YAML anchors that can be referenced for some common
 # object type normalizations like user-session, socket, or process.
 macros:
-  - &defaults
-    subject:
-      primary: auid
-      secondary: uid
-    how: [exe, comm]
-
   - &macro-user-session
     subject:
       primary: auid
@@ -17,21 +11,6 @@ macros:
       secondary: [addr, hostname]
       what: user-session
     how: [exe, terminal]
-
-  - &macro-socket
-    <<: *defaults
-    object:
-      primary: [addr, path]
-      secondary: port
-      what: socket
-
-  - &macro-process
-    <<: *defaults
-    object:
-      primary: [cmd, exe, comm]
-      secondary: pid
-      what: process
-    how: terminal
 
   - &ecs-iam
     category: iam
@@ -1539,6 +1518,7 @@ normalizations:
     object:
       primary: addr
       secondary: [rport]
+      what: user-session
     record_types: CRYPTO_SESSION
     source_ip: [addr]
     ecs: *ecs-process

--- a/aucoalesce/normalize.go
+++ b/aucoalesce/normalize.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/aucoalesce/normalize_test.go
+++ b/aucoalesce/normalize_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNormInit(t *testing.T) {

--- a/cmd/auparse/auparse.go
+++ b/cmd/auparse/auparse.go
@@ -27,7 +27,7 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/go-libaudit/v2"
 	"github.com/elastic/go-libaudit/v2/aucoalesce"

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,10 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.11.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rule/gen_testdata_test.go
+++ b/rule/gen_testdata_test.go
@@ -33,7 +33,7 @@ import (
 	"testing"
 
 	"github.com/kballard/go-shellquote"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/go-libaudit/v2"
 	"github.com/elastic/go-libaudit/v2/sys"

--- a/rule/rule_integ_test.go
+++ b/rule/rule_integ_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/go-libaudit/v2/rule"
 	"github.com/elastic/go-libaudit/v2/rule/flags"


### PR DESCRIPTION
Since there is already a dependency on yaml.v3, we might as well upgrade the project to use yaml.v3 too.

One change that affected normalizations.yaml was how YAML anchors are merged so I needed to add the `what: user-session` to retain the previous output in tests.

Also in normalizations.yaml I noticed there were unused macros and I removed them.

This relates to https://github.com/advisories/GHSA-hp87-p4gw-j4gq which was flagged by Github after intoduction in bebb5c6, but the project is not vulnerable as per https://pkg.go.dev/vuln/GO-2022-0603 because it does not use gopkg.in/yaml.v3#Unmarshal.