### PR TITLE
chore: set `SOCK_CLOEXEC` on socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Fix panic in `parseSockaddr` for malformed socket address. [#152](https://github.com/elastic/go-libaudit/pull/152)
+- Set `SOCK_CLOEXEC` when creating the netlink socket to avoid leaking file descriptors. [#165](https://github.com/elastic/go-libaudit/pull/165)
 
 ### Removed
 

--- a/netlink.go
+++ b/netlink.go
@@ -77,7 +77,7 @@ type NetlinkClient struct {
 //
 // The returned NetlinkClient must be closed with Close() when finished.
 func NewNetlinkClient(proto int, groups uint32, readBuf []byte, resp io.Writer) (*NetlinkClient, error) {
-	s, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, proto)
+	s, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW|syscall.SOCK_CLOEXEC, proto)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Set `SOCK_CLOEXEC` when creating the socket to avoid leaking file descriptors.