### PR TITLE
Fix filter by arch on ppc64le

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- rule: On ppc64le, fix handling of rules with filters like `-F arch=b64` or `-F arch=b32`. [#175](https://github.com/elastic/go-libaudit/pull/175)
+
 ### Removed
 
 ### Deprecated

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -865,7 +865,7 @@ func getArch(arch string) (string, uint32, error) {
 		}
 
 		switch runtimeArch {
-		case "aarch64", "x86_64", "ppc64", "s390x":
+		case "aarch64", "x86_64", "ppc64", "ppc64le", "s390x":
 			realArch = runtimeArch
 		default:
 			return "", 0, fmt.Errorf("cannot use b64 on %v", runtimeArch)
@@ -883,7 +883,7 @@ func getArch(arch string) (string, uint32, error) {
 			realArch = "arm"
 		case "x86_64":
 			realArch = "i386"
-		case "ppc64":
+		case "ppc64", "ppc64le":
 			realArch = "ppc"
 		case "s390x":
 			realArch = "s390"


### PR DESCRIPTION
Allow adding rules with filters like "-F arch=b64" and "-F arch=b32" on ppc64le.
Fixes https://github.com/elastic/go-libaudit/issues/174