### PR TITLE
Use non-blocking send on pid unset, retry on close

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -547,10 +547,11 @@ func (c *AuditClient) closeAndUnsetPid() error {
 					return err
 				}
 			}
-		} else {
-			// if we get another error from the send, return that up
-			return err
+			// try again after we flush the recv buffer
+			continue
 		}
+		// if we get another error from the send, return that up
+		return err
 
 	}
 	// we may not want to treat this as a hard error?

--- a/audit.go
+++ b/audit.go
@@ -432,7 +432,6 @@ func (c *AuditClient) Close() error {
 		if c.clearPIDOnClose {
 			// Unregister from the kernel for a clean exit.
 			err = c.closeAndUnsetPid()
-
 		}
 
 		err = errors.Join(err, c.Netlink.Close())

--- a/audit.go
+++ b/audit.go
@@ -547,6 +547,9 @@ func (c *AuditClient) closeAndUnsetPid() error {
 					return err
 				}
 			}
+		} else {
+			// if we get another error from the send, return that up
+			return err
 		}
 
 	}

--- a/audit.go
+++ b/audit.go
@@ -431,7 +431,8 @@ func (c *AuditClient) Close() error {
 	c.closeOnce.Do(func() {
 		if c.clearPIDOnClose {
 			// Unregister from the kernel for a clean exit.
-			c.closeAndUnsetPid()
+			err = c.closeAndUnsetPid()
+
 		}
 
 		err = errors.Join(err, c.Netlink.Close())

--- a/audit.go
+++ b/audit.go
@@ -539,16 +539,19 @@ func (c *AuditClient) closeAndUnsetPid() error {
 					// receive would block, try to send again
 					break
 				} else {
+					// if receive returns an other error, just return that.
 					return err
 				}
 			}
 		} else {
-			// if we have another kind of error, just bail and return that error.
+			// if Send returns and other error, just return that
 			return err
 		}
 
 	}
 	// we may not want to treat this as a hard error?
+	// It's not a massive error if this fails, since the kernel will unset the PID if it can't communicate with the process,
+	// so this is largely for neatness.
 	return fmt.Errorf("could not unset pid from audit after retries")
 }
 

--- a/audit.go
+++ b/audit.go
@@ -520,34 +520,29 @@ func (c *AuditClient) closeAndUnsetPid() error {
 	// The auditd code (which I'm using as a reference implementation) doesn't wait for a response when unsetting the audit pid.
 	// The retry count here is largely arbitrary, and provides a buffer for either transient errors (EINTR) or retries.
 	retries := 5
-outer:
+	// outer:
 	for i := 0; i < retries; i++ {
 		_, err := c.Netlink.SendNoWait(msg)
-		switch err {
-		case nil:
-			// send good, return
-			return nil
-		case syscall.EINTR:
+		if errors.Is(err, syscall.EINTR) {
 			// got a transient interrupt, try again
 			continue
-		case syscall.EAGAIN:
+		} else if errors.Is(err, syscall.EAGAIN) {
 			// send would block, try to drain the receive socket. The recv count here is just so we have enough of a buffer to attempt a send again
 			maxRecv := 10000
 			for i := 0; i < maxRecv; i++ {
 				_, err = c.Netlink.Receive(true, noParse)
-				switch err {
-				case nil, syscall.EINTR, syscall.ENOBUFS:
+				if err == nil || errors.Is(err, syscall.EINTR) || errors.Is(err, syscall.ENOBUFS) {
 					// continue with receive, try to read more data
 					continue
-				case syscall.EAGAIN:
+				} else if errors.Is(err, syscall.EAGAIN) {
 					// receive would block, try to send again
-					continue outer
-				default:
-					// if we have another kind of error, just bail and return that error.
+					break
+				} else {
 					return err
 				}
 			}
-		default:
+		} else {
+			// if we have another kind of error, just bail and return that error.
 			return err
 		}
 

--- a/audit.go
+++ b/audit.go
@@ -524,8 +524,7 @@ func (c *AuditClient) closeAndUnsetPid() {
 	// The auditd code (which I'm using as a reference implementation) doesn't wait for a response when unsetting the  audit pid.
 	_, err := c.Netlink.SendNoWait(msg)
 	if err != nil {
-		// sending may be blocked, retry. If the kernel layer is blocked, we'll usually get ENOBUF,
-		// but retry on any error.
+		// sending may be blocked, retry.
 		for {
 			// throw out events until we can try to send again. We're closing, so we don't really care.
 			_, err = c.Netlink.Receive(true, noParse)

--- a/audit.go
+++ b/audit.go
@@ -526,8 +526,9 @@ func (c *AuditClient) closeAndUnsetPid() error {
 		if errors.Is(err, syscall.EINTR) {
 			// got a transient interrupt, try again
 			continue
-		} else if errors.Is(err, syscall.EAGAIN) {
-			// send would block, try to drain the receive socket. The recv count here is just so we have enough of a buffer to attempt a send again
+		} else if errors.Is(err, syscall.EAGAIN) { //nolint:revive // easier to read with the else blocks
+			// send would block, try to drain the receive socket. The recv count here is just so we have enough of a buffer to attempt a send again/
+			// The number is just here so we ideally have enough of a buffer to attempt the send again.
 			maxRecv := 10000
 			for i := 0; i < maxRecv; i++ {
 				_, err = c.Netlink.Receive(true, noParse)

--- a/audit.go
+++ b/audit.go
@@ -529,6 +529,7 @@ func (c *AuditClient) closeAndUnsetPid() {
 			// throw out events until we can try to send again. We're closing, so we don't really care.
 			_, err = c.Netlink.Receive(true, noParse)
 			// if we got some events, or we would be waiting, try again try sending again
+			// If we get an ENOBUF, should we try to drain the socket, or retry first? This assumes we keep draining the socket.
 			if err == nil || errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
 				_, err := c.Netlink.SendNoWait(msg)
 				if err == nil {

--- a/audit.go
+++ b/audit.go
@@ -432,7 +432,6 @@ func (c *AuditClient) Close() error {
 		if c.clearPIDOnClose {
 			// Unregister from the kernel for a clean exit.
 			c.closeAndUnsetPid()
-
 		}
 
 		err = errors.Join(err, c.Netlink.Close())

--- a/audit.go
+++ b/audit.go
@@ -518,41 +518,40 @@ func (c *AuditClient) closeAndUnsetPid() error {
 		return nil, nil
 	}
 
-	// retry the send if the syscall gets an interrupt.
-	// This may not be totally needed, as non-blocking calls shouldn't really return an EINTR, but there's nothing saying it can't.
-	retryOnEINTR := func(msg syscall.NetlinkMessage) (uint32, error) {
-		maxRetry := 10
-		for i := 0; i < maxRetry; i++ {
-			wrote, err := c.Netlink.SendNoWait(msg)
-			if !errors.Is(err, syscall.EINTR) {
-				return wrote, err
-			}
-		}
-		return 0, fmt.Errorf("could not send netlink message, got repeated EINTR")
-	}
-
 	// If our request to unset the PID would block, then try to drain events from
 	// the netlink socket, resend, try again.
 	// In netlink, EAGAIN usually indicates our read buffer is full.
-	// The auditd code (which I'm using as a reference implementation) doesn't wait for a response when unsetting the  audit pid.
-	_, err := retryOnEINTR(msg)
-	if err != nil {
-		maxRetry := 10000
-		// sending may be blocked, try to empty the buffer, then send again
-		for i := 0; i < maxRetry; i++ {
-			// Attempt to drain the socket before we retry the close
-			_, err = c.Netlink.Receive(true, noParse)
-			if err == nil || errors.Is(err, syscall.EINTR) || errors.Is(err, syscall.ENOBUFS) {
-				continue
-			} else if errors.Is(err, syscall.EAGAIN) {
-				break
+	// The auditd code (which I'm using as a reference implementation) doesn't wait for a response when unsetting the audit pid.
+	maxLoop := 5
+	for i := 0; i < maxLoop; i++ {
+		_, err := c.Netlink.SendNoWait(msg)
+		// if we get an interrupt, retry the send
+		if err == nil {
+			return nil
+		} else if errors.Is(err, syscall.EINTR) {
+			// got interrupt, try again
+			continue
+		} else if errors.Is(err, syscall.EAGAIN) {
+			maxRecv := 10000
+			// send would block, try to drain the receive socket
+			for i := 0; i < maxRecv; i++ {
+				_, err = c.Netlink.Receive(true, noParse)
+				if errors.Is(err, syscall.EAGAIN) {
+					// receive would block, try to send again
+					break
+				} else if err == nil || errors.Is(err, syscall.EINTR) || errors.Is(err, syscall.ENOBUFS) {
+					// retry the receive
+					continue
+				} else {
+					// if we have another kind of error, just bail and return that error.
+					return err
+				}
 			}
 		}
+
 	}
-	// One last attempt.
-	// Looking at the kernel code in kauditd_thread, I think we can survive failing to unset the pid, as connection failures will cause the pid to be unset.
-	_, err = retryOnEINTR(msg)
-	return fmt.Errorf("error sending PID unset event: %w", err)
+	// we may not want to treat this as a hard error?
+	return fmt.Errorf("could not unset pid from audit after retries")
 }
 
 func (c *AuditClient) set(status AuditStatus, mode WaitMode) error {

--- a/audit.go
+++ b/audit.go
@@ -535,6 +535,9 @@ func (c *AuditClient) closeAndUnsetPid() {
 				if err == nil {
 					break
 				}
+				// Not sure how we could end up here unless other threads are doing something weird, but best to handle this so we don't loop forever.
+			} else if errors.Is(err, syscall.EBADFD) {
+				return
 			}
 
 		}

--- a/audit_test.go
+++ b/audit_test.go
@@ -64,23 +64,23 @@ type TestNetlinkIface struct {
 	sendStack []error
 }
 
-func (tn *TestNetlinkIface) Close() error {
+func (_ *TestNetlinkIface) Close() error {
 	return nil
 }
 
-func (tn *TestNetlinkIface) Send(msg syscall.NetlinkMessage) (uint32, error) {
+func (tn *TestNetlinkIface) Send(_ syscall.NetlinkMessage) (uint32, error) {
 	top := tn.sendStack[0]
 	tn.sendStack = slices.Delete(tn.sendStack, 0, 1)
 	return 0, top
 }
 
-func (tn *TestNetlinkIface) SendNoWait(msg syscall.NetlinkMessage) (uint32, error) {
+func (tn *TestNetlinkIface) SendNoWait(_ syscall.NetlinkMessage) (uint32, error) {
 	top := tn.sendStack[0]
 	tn.sendStack = slices.Delete(tn.sendStack, 0, 1)
 	return 0, top
 }
 
-func (tn *TestNetlinkIface) Receive(nonBlocking bool, p NetlinkParser) ([]syscall.NetlinkMessage, error) {
+func (tn *TestNetlinkIface) Receive(_ bool, _ NetlinkParser) ([]syscall.NetlinkMessage, error) {
 	top := tn.recvStack[0]
 	tn.recvStack = slices.Delete(tn.recvStack, 0, 1)
 	return nil, top

--- a/audit_test.go
+++ b/audit_test.go
@@ -64,7 +64,7 @@ type TestNetlinkIface struct {
 	sendStack []error
 }
 
-func (_ *TestNetlinkIface) Close() error {
+func (*TestNetlinkIface) Close() error {
 	return nil
 }
 
@@ -84,7 +84,6 @@ func (tn *TestNetlinkIface) Receive(_ bool, _ NetlinkParser) ([]syscall.NetlinkM
 	top := tn.recvStack[0]
 	tn.recvStack = slices.Delete(tn.recvStack, 0, 1)
 	return nil, top
-
 }
 
 func TestCloseBehavior(t *testing.T) {
@@ -138,7 +137,6 @@ func TestCloseBehavior(t *testing.T) {
 			require.True(t, errors.Is(err, test.err))
 		})
 	}
-
 }
 
 func TestAuditClientGetStatus(t *testing.T) {

--- a/netlink.go
+++ b/netlink.go
@@ -127,7 +127,7 @@ func getPortID(fd int) (uint32, error) {
 	return addr.Pid, nil
 }
 
-// Send a message to the netlink client in non-blocking mode. Behavior is otherwise identical to Send()
+// SendNoWait sends a message to the netlink client in non-blocking mode. Behavior is otherwise identical to Send()
 func (c *NetlinkClient) SendNoWait(msg syscall.NetlinkMessage) (uint32, error) {
 	return c.send(msg, syscall.MSG_DONTWAIT)
 }

--- a/netlink.go
+++ b/netlink.go
@@ -36,6 +36,7 @@ import (
 // in the message and an error if it occurred.
 type NetlinkSender interface {
 	Send(msg syscall.NetlinkMessage) (uint32, error)
+	SendNoWait(msg syscall.NetlinkMessage) (uint32, error)
 }
 
 // NetlinkReceiver receives data from the netlink socket and uses the provided
@@ -126,17 +127,26 @@ func getPortID(fd int) (uint32, error) {
 	return addr.Pid, nil
 }
 
+// Send a message to the netlink client in non-blocking mode. Behavior is otherwise identical to Send()
+func (c *NetlinkClient) SendNoWait(msg syscall.NetlinkMessage) (uint32, error) {
+	return c.send(msg, syscall.MSG_DONTWAIT)
+}
+
 // Send sends a netlink message and returns the sequence number used
 // in the message and an error if it occurred. If the PID is not set then
 // the value will be populated automatically (recommended).
 func (c *NetlinkClient) Send(msg syscall.NetlinkMessage) (uint32, error) {
+	return c.send(msg, 0)
+}
+
+func (c *NetlinkClient) send(msg syscall.NetlinkMessage, flags int) (uint32, error) {
 	if msg.Header.Pid == 0 {
 		msg.Header.Pid = c.pid
 	}
 
 	msg.Header.Seq = atomic.AddUint32(&c.seq, 1)
 	to := &syscall.SockaddrNetlink{}
-	return msg.Header.Seq, syscall.Sendto(c.fd, serialize(msg), 0, to)
+	return msg.Header.Seq, syscall.Sendto(c.fd, serialize(msg), flags, to)
 }
 
 func serialize(msg syscall.NetlinkMessage) []byte {


### PR DESCRIPTION
Tinkering with an alternative to https://github.com/elastic/beats/pull/42933, by trying to drain the socket on close if we get an error while trying to unset the pid.

This is meant as an alternative fix for https://github.com/elastic/beats/issues/26031, where we do a non-blocking write and try to drain the socket instead of starting a second goroutine. 

In draft, as I'm still testing and figuring out how netlink handles errors.